### PR TITLE
Don't try to load module if there is none

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -265,16 +265,17 @@ abstract class Collector
 	protected function GetVersionFromModuleFile()
 	{
 		$aFiles = glob(APPROOT.'collectors/module.*.php');
-		$sModuleFile = null;
-		$sModuleFile = reset($aFiles);
-		if ($sModuleFile == null)
+		if (!$aFiles)
 		{
 			// No module found, use a default value...
 			$this->sVersion = '1.0.0';
+			Utils::Log(LOG_INFO, "No module file found, using default version value.");
+			return;
 		}
 		
 		try
 		{
+			$sModuleFile = reset($aFiles);
 			$sModuleFileContents = file_get_contents($sModuleFile);
 			$sModuleFileContents = str_replace(array('<?php', '?>'), '', $sModuleFileContents);
 			$sModuleFileContents = str_replace('SetupWebPage::AddModule(', '$this->InitVersionCallback(', $sModuleFileContents);


### PR DESCRIPTION
This would generate a warning every run. Now I made it an info log message.

Also fixed a php warning of glob returning false instead of empty array in [some cases](https://3v4l.org/qZ4hC).

This will fix #4, I had problems updating that branch.