### PR TITLE
Fix other request errors displayed as successful

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -674,6 +674,12 @@ abstract class Collector
 				}
 			}
 		}
+		else
+		{
+			Utils::Log(LOG_ERR, "Synchronization of data source '{$this->sSourceName}' failed.");
+			$this->sErrorMessage .= $sResult;
+			$iErrorsCount = 1;
+		}
 		if ($iErrorsCount == 0)
 		{
 			Utils::Log(LOG_INFO, "Synchronization of data source '{$this->sSourceName}' succeeded.");


### PR DESCRIPTION
The `Collector::Synchronize` method does not check if synchro has succeeded. 

In my case, php was throwing a memory limit error and the data collector said it was succeeded, but in the iTop console I saw it was still running (meaning it was broken down).