### PR TITLE
Allow login_mode to be set

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -4,7 +4,7 @@
   <itop_url>https://localhost/iTop</itop_url>
   <itop_login>admin</itop_login>
   <itop_password>admin</itop_password>
-  <itop_login_mode>form</itop_login_mode>
+  <itop_login_mode></itop_login_mode>
   
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -4,6 +4,7 @@
   <itop_url>https://localhost/iTop</itop_url>
   <itop_login>admin</itop_login>
   <itop_password>admin</itop_password>
+  <itop_login_mode>form</itop_login_mode>
   
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -581,6 +581,7 @@ abstract class Collector
 			$this->DoProcessBeforeSynchro();
 		}
 		
+		$sLoginMode = Utils::GetConfigurationValue('itop_login_mode', 'form');
 		$aFiles = glob(Utils::GetDataFilePath(get_class($this).'-*.csv'));
 		foreach($aFiles as $sDataFile)
 		{
@@ -598,7 +599,7 @@ abstract class Collector
 				'charset' => $this->GetCharset(),
 			);
 			$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_import.php';
-			$sUrl .= '?login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
+			if (!empty($sLoginMode)) $sUrl .= '?login_mode=' . $sLoginMode;
     		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run	
 
 	    	$aResponseHeaders = null;
@@ -641,7 +642,8 @@ abstract class Collector
 			$aData['max_chunk_size'] = $iMaxChunkSize;
 		}
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_exec.php';
-		$sUrl .= '?login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
+		if (!empty($sLoginMode)) $sUrl .= '?login_mode=' . $sLoginMode;
+
 		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run
 		
 		$aResponseHeaders = null;

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -598,6 +598,7 @@ abstract class Collector
 				'charset' => $this->GetCharset(),
 			);
 			$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_import.php';
+			$sUrl .= '?login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
     		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run	
 
 	    	$aResponseHeaders = null;
@@ -640,6 +641,7 @@ abstract class Collector
 			$aData['max_chunk_size'] = $iMaxChunkSize;
 		}
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_exec.php';
+		$sUrl .= '?login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
 		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run
 		
 		$aResponseHeaders = null;

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -599,7 +599,7 @@ abstract class Collector
 				'charset' => $this->GetCharset(),
 			);
 			$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_import.php';
-			if (!empty($sLoginMode)) $sUrl .= '?login_mode=' . $sLoginMode;
+			if (!empty($sLoginMode)) { $sUrl .= '?login_mode=' . $sLoginMode;}
     		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run	
 
 	    	$aResponseHeaders = null;
@@ -642,7 +642,7 @@ abstract class Collector
 			$aData['max_chunk_size'] = $iMaxChunkSize;
 		}
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/synchro/synchro_exec.php';
-		if (!empty($sLoginMode)) $sUrl .= '?login_mode=' . $sLoginMode;
+		if (!empty($sLoginMode)) { $sUrl .= '?login_mode=' . $sLoginMode;}
 
 		$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run
 		

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -110,7 +110,8 @@ class RestClient
 		$aData['json_data'] = json_encode($aOperation);
 
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/webservices/rest.php?version='.$sVersion;
-		$sUrl .= '&login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
+		$sLoginMode = Utils::GetConfigurationValue('itop_login_mode', 'form');
+		if (!empty($sLoginMode)) $sUrl .= '&login_mode=' . $sLoginMode;
 		$aHeaders = array();
 		$aRawCurlOptions = Utils::GetConfigurationValue('curl_options', array());
 		$aCurlOptions = array();

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -111,7 +111,7 @@ class RestClient
 
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/webservices/rest.php?version='.$sVersion;
 		$sLoginMode = Utils::GetConfigurationValue('itop_login_mode', 'form');
-		if (!empty($sLoginMode)) $sUrl .= '&login_mode=' . $sLoginMode;
+		if (!empty($sLoginMode)) { $sUrl .= '&login_mode=' . $sLoginMode;}
 		$aHeaders = array();
 		$aRawCurlOptions = Utils::GetConfigurationValue('curl_options', array());
 		$aCurlOptions = array();

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -108,8 +108,9 @@ class RestClient
 		$aData['auth_user'] = Utils::GetConfigurationValue('itop_login', '');
 		$aData['auth_pwd'] = Utils::GetConfigurationValue('itop_password', '');
 		$aData['json_data'] = json_encode($aOperation);
-//print_r($aOperation);
+
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/webservices/rest.php?version='.$sVersion;
+		$sUrl .= '&login_mode=' . Utils::GetConfigurationValue('itop_login_mode', 'form');
 		$aHeaders = array();
 		$aRawCurlOptions = Utils::GetConfigurationValue('curl_options', array());
 		$aCurlOptions = array();
@@ -127,7 +128,7 @@ class RestClient
 		{
 			throw new Exception("rest.php replied: $response");
 		}
-//print_r($aResults);
+
 		return $aResults;
 	}
 	


### PR DESCRIPTION
In the case where the first `allowed_login_types` is for example `saml`, then the calls to the API will be redirected to the SAML identity provider, but this is not supported by the curl calls.

Solution is to put `login_mode=form` as an extra URL parameter. I have made it configurable in case of any other situation that is not using form by default.