### PR TITLE
N°5600 - Create enhanced collector::CheckColumns method and factorize JSON, CSV and SQL equivalent methods to it

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -952,21 +952,24 @@ abstract class Collector
 				continue;
 			}
 			// Skip optional attributes
-			if (!$this->AttributeIsOptional($sCode)) {
-				// Check for missing columns
-				if (!array_key_exists($sCode, $aSynchroColumns) && $aDefs['reconcile']) {
-					Utils::Log(LOG_ERR, '['.$sClass.'] The column "'.$sCode.'", used for reconciliation, is missing in the '.$sSource.'.');
-					$iError++;
-				} elseif (!array_key_exists($sCode, $aSynchroColumns) && $aDefs['update']) {
-					Utils::Log(LOG_ERR, '['.$sClass.'] The column "'.$sCode.'", used for update, is missing in the '.$sSource.'.');
-					$iError++;
-				}
-
-				// Check for useless columns
-				if (array_key_exists($sCode, $aSynchroColumns) && !$aDefs['reconcile'] && !$aDefs['update']) {
-					Utils::Log(LOG_WARNING, '['.$sClass.'] The column "'.$sCode.'" is used neither for update nor for reconciliation.');
-				}
+			if ($this->AttributeIsOptional($sCode)) {
+				continue;
 			}
+
+			// Check for missing columns
+			if (!array_key_exists($sCode, $aSynchroColumns) && $aDefs['reconcile']) {
+				Utils::Log(LOG_ERR, '['.$sClass.'] The column "'.$sCode.'", used for reconciliation, is missing in the '.$sSource.'.');
+				$iError++;
+			} elseif (!array_key_exists($sCode, $aSynchroColumns) && $aDefs['update']) {
+				Utils::Log(LOG_ERR, '['.$sClass.'] The column "'.$sCode.'", used for update, is missing in the '.$sSource.'.');
+				$iError++;
+			}
+
+			// Check for useless columns
+			if (array_key_exists($sCode, $aSynchroColumns) && !$aDefs['reconcile'] && !$aDefs['update']) {
+				Utils::Log(LOG_WARNING, '['.$sClass.'] The column "'.$sCode.'" is used neither for update nor for reconciliation.');
+			}
+
 		}
 
 		if ($iError > 0) {

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -301,7 +301,6 @@ abstract class CSVCollector extends Collector
 	protected function CheckColumns($aSynchroColumns, $aColumnsToIgnore, $sSource)
 	{
 		Utils::Log(LOG_DEBUG, "[".get_class($this)."] Columns [".var_export($this->aSynchroColumns, true)."]");
-		$aColumnsToIgnore = [];
 		foreach ($this->aFields as $sSynchroColumn => $aDefs) {
 			if (array_key_exists($sSynchroColumn, $this->aSynchroFieldsToDefaultValues) || in_array($sSynchroColumn, $this->aIgnoredSynchroFields)) {
 				$aColumnsToIgnore[] = $sSynchroColumn;

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -300,14 +300,14 @@ abstract class CSVCollector extends Collector
 	 */
 	protected function CheckColumns($aSynchroColumns, $aColumnsToIgnore, $sSource)
 	{
-		Utils::Log(LOG_DEBUG, "[".get_class($this)."] Columns [".var_export($this->aSynchroColumns, true)."]");
+		Utils::Log(LOG_DEBUG, "[".get_class($this)."] Columns [".var_export($aSynchroColumns, true)."]");
 		foreach ($this->aFields as $sSynchroColumn => $aDefs) {
 			if (array_key_exists($sSynchroColumn, $this->aSynchroFieldsToDefaultValues) || in_array($sSynchroColumn, $this->aIgnoredSynchroFields)) {
 				$aColumnsToIgnore[] = $sSynchroColumn;
 			}
 		}
 
-		parent::CheckColumns($this->aSynchroColumns, $aColumnsToIgnore, $sSource);
+		parent::CheckColumns($aSynchroColumns, $aColumnsToIgnore, $sSource);
 	}
 }
 

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -307,7 +307,7 @@ abstract class CSVCollector extends Collector
 			}
 		}
 
-		parent::CheckColumns($this->aSynchroColumns, $aColumnsToIgnore, 'csv file');
+		parent::CheckColumns($this->aSynchroColumns, $aColumnsToIgnore, $sSource);
 	}
 }
 

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -160,14 +160,12 @@ abstract class CSVCollector extends Collector
 
 		try {
 			$hHandle = fopen($sCsvFilePath, "r");
-		}
-		catch (Exception $e) {
+		} catch (Exception $e) {
 			Utils::Log(LOG_INFO, "[".get_class($this)."] Cannot open CSV file $sCsvFilePath");
 			$sCsvFilePath = APPROOT.$sCsvFilePath;
 			try {
 				$hHandle = fopen($sCsvFilePath, "r");
-			}
-			catch (Exception $e) {
+			} catch (Exception $e) {
 				Utils::Log(LOG_ERR, "[".get_class($this)."] Cannot open CSV file $sCsvFilePath");
 
 				return false;
@@ -225,16 +223,7 @@ abstract class CSVCollector extends Collector
 			$aCsvHeaderColumns = $oNextLineArr->getValues();
 
 			$this->Configure($aCsvHeaderColumns);
-
-			Utils::Log(LOG_DEBUG, "[".get_class($this)."] Columns [".var_export($this->aSynchroColumns, true)."]");
-			$aColumnsToIgnore = [];
-			foreach ($this->aFields as $sSynchroColumn => $aDefs) {
-				if (array_key_exists($sSynchroColumn, $this->aSynchroFieldsToDefaultValues)
-					|| in_array($sSynchroColumn, $this->aIgnoredSynchroFields)) {
-					$aColumnsToIgnore[] = $sSynchroColumn;
-				}
-			}
-			$this->CheckColumns($this->aSynchroColumns, $aColumnsToIgnore, 'csv file');
+			$this->CheckColumns($this->aSynchroColumns, [], 'csv file');
 
 			if ($this->bHasHeader) {
 				$this->iIdx++;
@@ -306,6 +295,21 @@ abstract class CSVCollector extends Collector
 		}
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	protected function CheckColumns($aSynchroColumns, $aColumnsToIgnore, $sSource)
+	{
+		Utils::Log(LOG_DEBUG, "[".get_class($this)."] Columns [".var_export($this->aSynchroColumns, true)."]");
+		$aColumnsToIgnore = [];
+		foreach ($this->aFields as $sSynchroColumn => $aDefs) {
+			if (array_key_exists($sSynchroColumn, $this->aSynchroFieldsToDefaultValues) || in_array($sSynchroColumn, $this->aIgnoredSynchroFields)) {
+				$aColumnsToIgnore[] = $sSynchroColumn;
+			}
+		}
+
+		parent::CheckColumns($this->aSynchroColumns, $aColumnsToIgnore, 'csv file');
+	}
 }
 
 class NextLineObject

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -294,16 +294,7 @@ abstract class JsonCollector extends Collector
 			}
 
 			if ($this->iIdx == 0) {
-				$aChecks = $this->CheckJSONFields($aDataToSynchronize);
-				foreach ($aChecks['errors'] as $sError) {
-					Utils::Log(LOG_ERR, "[".get_class($this)."] $sError");
-				}
-				foreach ($aChecks['warnings'] as $sWarning) {
-					Utils::Log(LOG_WARNING, "[".get_class($this)."] $sWarning");
-				}
-				if (count($aChecks['errors']) > 0) {
-					throw new Exception("Missing columns in the Json file.");
-				}
+				$this->CheckColumns($aDataToSynchronize, [], 'Json file');
 			}
 			//check if all expected fields are in array. If not add it with null value
 			foreach ($this->aCSVHeaders as $sHeader) {
@@ -349,38 +340,6 @@ abstract class JsonCollector extends Collector
 		}
 
 		return parent::AttributeIsOptional($sAttCode);
-	}
-
-	/**
-	 * Check if the keys of the supplied hash array match the expected fields
-	 *
-	 * @param array $aData
-	 *
-	 * @return array A hash array with two entries: 'errors' => array of strings and 'warnings' => array of strings
-	 */
-	protected function CheckJSONFields($aData)
-	{
-		$aRet = array('errors' => array(), 'warnings' => array());
-
-		if (!array_key_exists('primary_key', $aData)) {
-			$aRet['errors'][] = 'The mandatory column "primary_key" is missing from the query.';
-		}
-		foreach ($this->aFields as $sCode => $aDefs) {
-			// Check for missing columns
-			if (!array_key_exists($sCode, $aData) && $aDefs['reconcile']) {
-				$aRet['errors'][] = 'The column "'.$sCode.'", used for reconciliation, is missing from the query.';
-			} else if (!array_key_exists($sCode, $aData) && $aDefs['update']) {
-				$aRet['errors'][] = 'The column "'.$sCode.'", used for update, is missing from the query.';
-			}
-
-			// Check for useless columns
-			if (array_key_exists($sCode, $aData) && !$aDefs['reconcile'] && !$aDefs['update']) {
-				$aRet['warnings'][] = 'The column "'.$sCode.'" is used neither for update nor for reconciliation.';
-			}
-
-		}
-
-		return $aRet;
 	}
 
 }

--- a/core/sqlcollector.class.inc.php
+++ b/core/sqlcollector.class.inc.php
@@ -149,16 +149,7 @@ abstract class SQLCollector extends Collector
 			}
 
 			if ($this->idx == 0) {
-				$aChecks = $this->CheckSQLColumn($aData);
-				foreach ($aChecks['errors'] as $sError) {
-					Utils::Log(LOG_ERR, "[".get_class($this)."] $sError");
-				}
-				foreach ($aChecks['warnings'] as $sWarning) {
-					Utils::Log(LOG_WARNING, "[".get_class($this)."] $sWarning");
-				}
-				if (count($aChecks['errors']) > 0) {
-					throw new Exception("Missing columns in the SQL query.");
-				}
+				$this->CheckColumns($aData, [], 'SQL query');
 			}
 			$this->idx++;
 
@@ -197,38 +188,6 @@ abstract class SQLCollector extends Collector
 		}
 
 		return parent::AttributeIsOptional($sAttCode);
-	}
-
-	/**
-	 * Check if the keys of the supplied hash array match the expected fields
-	 *
-	 * @param array $aData
-	 *
-	 * @return array A hash array with two entries: 'errors' => array of strings and 'warnings' => array of strings
-	 */
-	protected function CheckSQLColumn($aData)
-	{
-		$aRet = array('errors' => array(), 'warnings' => array());
-
-		if (!array_key_exists('primary_key', $aData)) {
-			$aRet['errors'][] = 'The mandatory column "primary_key" is missing from the query.';
-		}
-		foreach ($this->aFields as $sCode => $aDefs) {
-			// Check for missing columns
-			if (!array_key_exists($sCode, $aData) && $aDefs['reconcile']) {
-				$aRet['errors'][] = 'The column "'.$sCode.'", used for reconciliation, is missing from the query.';
-			} else if (!array_key_exists($sCode, $aData) && $aDefs['update']) {
-				$aRet['errors'][] = 'The column "'.$sCode.'", used for update, is missing from the query.';
-			}
-
-			// Check for useless columns
-			if (array_key_exists($sCode, $aData) && !$aDefs['reconcile'] && !$aDefs['update']) {
-				$aRet['warnings'][] = 'The column "'.$sCode.'" is used neither for update nor for reconciliation.';
-			}
-
-		}
-
-		return $aRet;
 	}
 }
 


### PR DESCRIPTION
Purpose of this PR is to standardize and factorize the CheckSynchroColumns / CheckJSONFiedls / CheckSQLColumn methods that exists in csv, json and sql collectors and to slightly alter their behaviour to better handle "optional" attributes.

On the factorization front:
- a new CheckColumns method has been created in the Collector class,
- it replaces the CheckSynchroColumns method of the CSVCollector,
- it replaces the CheckJSONFields method of the JsonCollector as well as a few checks and logs made before its call,
- it replaces the CheckSQLColumn method of the SQLCollector as well as a few checks and logs made before its call.
The 3 legacy methods were doing the same things.

On the "optional" attribute front:
The CheckColumns method skips the checks done on an attribute if this one is optional. This feature significantly reduces the complexity of a collector (like the Azure one) by allowing the json files that describe the synchro policies for classes to hold information about attributes that maybe mandatory in a datamodel and not used in another datamodel.
Consequence is that the json file may hold the description of an attribute, attribute_1, with the option "update" set to 1 even if this attribute_1 is not used in some datamodel, knowing that this attribute is mandatory an another datamodel.
