### PR TITLE
N°5738 integrate SaaS collector enhancements

### DIFF
--- a/core/array_polyfill.php
+++ b/core/array_polyfill.php
@@ -1,0 +1,15 @@
+<?php
+
+if (!function_exists("array_is_list")) {
+	function array_is_list(array $array): bool {
+		$i = 0;
+		foreach ($array as $k => $v) {
+			if ($k !== $i++) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}
+

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -58,14 +58,14 @@ abstract class Collector
 		$this->sSynchroDataSourceDefinitionFile = APPROOT.'collectors/'.get_class($this).'.json';
 		$this->sVersion = null;
 		$this->iSourceId = null;
-		$this->aFields = array();
-		$this->aCSVHeaders = array();
+		$this->aFields = [];
+		$this->aCSVHeaders = [];
 		$this->aCSVFile = array();
 		$this->iFileIndex = null;
-		$this->aCollectorConfig = array();
+		$this->aCollectorConfig = [];
 		$this->sErrorMessage = '';
 		$this->sSeparator = ';';
-		$this->aSkippedAttributes = array();
+		$this->aSkippedAttributes = [];
 
 		$sJSONSourceDefinition = $this->GetSynchroDataSourceDefinition();
 		if (empty($sJSONSourceDefinition)) {
@@ -83,7 +83,7 @@ abstract class Collector
 			throw new Exception('Cannot create Collector (invalid JSON definition)');
 		}
 		foreach ($aSourceDefinition['attribute_list'] as $aAttr) {
-			$this->aFields[$aAttr['attcode']] = array('class' => $aAttr['finalclass'], 'update' => ($aAttr['update'] != 0), 'reconcile' => ($aAttr['reconcile'] != 0));
+			$this->aFields[$aAttr['attcode']] = ['class' => $aAttr['finalclass'], 'update' => ($aAttr['update'] != 0), 'reconcile' => ($aAttr['reconcile'] != 0)];
 		}
 
 		$this->ReadCollectorConfig();
@@ -100,9 +100,9 @@ abstract class Collector
 	}
 
 	public function ReadCollectorConfig() {
-		$this->aCollectorConfig = Utils::GetConfigurationValue(get_class($this), array());
+		$this->aCollectorConfig = Utils::GetConfigurationValue(get_class($this),  []);
 		if (empty($this->aCollectorConfig)) {
-			$this->aCollectorConfig = Utils::GetConfigurationValue(strtolower(get_class($this)), array());
+			$this->aCollectorConfig = Utils::GetConfigurationValue(strtolower(get_class($this)), []);
 		}
 		Utils::Log(LOG_DEBUG,
 			sprintf("aCollectorConfig %s:  [%s]",

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -59,42 +59,37 @@ abstract class CSVCollector extends Collector
 	{
 		$bRet = parent::Prepare();
 
-		$aClassConfig = Utils::GetConfigurationValue(get_class($this));
-		if ($aClassConfig == '') {
-			$aClassConfig = Utils::GetConfigurationValue(strtolower(get_class($this)));
-		}
-
 		$this->sCsvSeparator = ';';
 		$this->sCsvEncoding = 'UTF-8';
 		$this->sCsvCliCommand = '';
 		$this->aSynchroFieldsToDefaultValues = array();
 		$this->bHasHeader = true;
 
-		if (is_array($aClassConfig)) {
-			if (array_key_exists('csv_file', $aClassConfig)) {
-				$sCsvFilePath = $aClassConfig['csv_file'];
+		if (is_array($this->aCollectorConfig)) {
+			if (array_key_exists('csv_file', $this->aCollectorConfig)) {
+				$sCsvFilePath = $this->aCollectorConfig['csv_file'];
 			}
 
-			if (array_key_exists('separator', $aClassConfig)) {
-				$this->sCsvSeparator = $aClassConfig['separator'];
+			if (array_key_exists('separator', $this->aCollectorConfig)) {
+				$this->sCsvSeparator = $this->aCollectorConfig['separator'];
 				if ($this->sCsvSeparator === 'TAB') {
 					$this->sCsvSeparator = "\t";
 				}
 			}
-			if (array_key_exists('encoding', $aClassConfig)) {
-				$this->sCsvEncoding = $aClassConfig['encoding'];
+			if (array_key_exists('encoding', $this->aCollectorConfig)) {
+				$this->sCsvEncoding = $this->aCollectorConfig['encoding'];
 			}
-			if (array_key_exists('command', $aClassConfig)) {
-				$this->sCsvCliCommand = $aClassConfig['command'];
+			if (array_key_exists('command', $this->aCollectorConfig)) {
+				$this->sCsvCliCommand = $this->aCollectorConfig['command'];
 			}
-			if (array_key_exists('has_header', $aClassConfig)) {
-				$this->bHasHeader = ($aClassConfig['has_header'] !== 'no');
+			if (array_key_exists('has_header', $this->aCollectorConfig)) {
+				$this->bHasHeader = ($this->aCollectorConfig['has_header'] !== 'no');
 			}
 
 
-			if (array_key_exists('defaults', $aClassConfig)) {
-				if ($aClassConfig['defaults'] !== '') {
-					$this->aSynchroFieldsToDefaultValues = $aClassConfig['defaults'];
+			if (array_key_exists('defaults', $this->aCollectorConfig)) {
+				if ($this->aCollectorConfig['defaults'] !== '') {
+					$this->aSynchroFieldsToDefaultValues = $this->aCollectorConfig['defaults'];
 					if (!is_array($this->aSynchroFieldsToDefaultValues)) {
 						Utils::Log(LOG_ERR,
 							"[".get_class($this)."] defaults section configuration is not correct. please see documentation.");
@@ -104,21 +99,21 @@ abstract class CSVCollector extends Collector
 				}
 			}
 
-			if (array_key_exists('ignored_columns', $aClassConfig)) {
-				if ($aClassConfig['ignored_columns'] !== '') {
-					if (!is_array($aClassConfig['ignored_columns'])) {
+			if (array_key_exists('ignored_columns', $this->aCollectorConfig)) {
+				if ($this->aCollectorConfig['ignored_columns'] !== '') {
+					if (!is_array($this->aCollectorConfig['ignored_columns'])) {
 						Utils::Log(LOG_ERR,
 							"[".get_class($this)."] ignored_columns section configuration is not correct. please see documentation.");
 
 						return false;
 					}
-					$this->aIgnoredCsvColumns = array_values($aClassConfig['ignored_columns']);
+					$this->aIgnoredCsvColumns = array_values($this->aCollectorConfig['ignored_columns']);
 				}
 			}
 
-			if (array_key_exists('fields', $aClassConfig)) {
-				if ($aClassConfig['fields'] !== '') {
-					$aCurrentConfiguredHeaderColumns = $aClassConfig['fields'];
+			if (array_key_exists('fields', $this->aCollectorConfig)) {
+				if ($this->aCollectorConfig['fields'] !== '') {
+					$aCurrentConfiguredHeaderColumns = $this->aCollectorConfig['fields'];
 					if (!is_array($aCurrentConfiguredHeaderColumns)) {
 						Utils::Log(LOG_ERR,
 							"[".get_class($this)."] fields section configuration is not correct. please see documentation.");

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -273,12 +273,13 @@ abstract class JsonCollector extends Collector
 	 * @return array
 	 * @throws \Exception
 	 */
-	private function SearchFieldValues($aData) {
+	private function SearchFieldValues($aData, $aTestOnlyFieldsKey=null) {
 		$aDataToSynchronize = array();
 
-		foreach ($this->aFieldsKey as $key => $sPath) {
+		$aCurrentFieldKeys = (is_null($aTestOnlyFieldsKey)) ? $this->aFieldsKey : $aTestOnlyFieldsKey;
+		foreach ($aCurrentFieldKeys as $key => $sPath) {
 			if ($this->iIdx == 0) {
-				Utils::Log(LOG_DEBUG, $key.":".array_search($key, $this->aFieldsKey));
+				Utils::Log(LOG_DEBUG, $key.":".array_search($key, $aCurrentFieldKeys));
 			}
 			//
 			$aJsonKeyPath = explode('/', $sPath);
@@ -324,7 +325,7 @@ abstract class JsonCollector extends Collector
 				}
 			}
 		}
-		
+
 		Utils::Log(LOG_DEBUG, '$aDataToSynchronize: '.json_encode($aDataToSynchronize));
 		return $aDataToSynchronize;
 	}

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -274,7 +274,7 @@ abstract class JsonCollector extends Collector
 	 * @throws \Exception
 	 */
 	private function SearchFieldValues($aData, $aTestOnlyFieldsKey=null) {
-		$aDataToSynchronize = array();
+		$aDataToSynchronize = [];
 
 		$aCurrentFieldKeys = (is_null($aTestOnlyFieldsKey)) ? $this->aFieldsKey : $aTestOnlyFieldsKey;
 		foreach ($aCurrentFieldKeys as $key => $sPath) {

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -292,10 +292,10 @@ abstract class JsonCollector extends Collector
 						$aValue = $aValue[$sTag];
 						$bFind = true;
 					}
-				} else if (array_is_list($aValue) && array_key_exists((int) $sTag, $aValue)) {
+				} /*else if (array_is_list($aValue) && array_key_exists((int) $sTag, $aValue)) {
 					$aValue = $aValue[(int) $sTag];
 					$bFind = true;
-				} else {
+				} */else {
 					$aNewValue = array();
 					foreach ($aValue as $aElement) {
 						if ($sTag == '*') //Any tag

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -292,10 +292,10 @@ abstract class JsonCollector extends Collector
 						$aValue = $aValue[$sTag];
 						$bFind = true;
 					}
-				} /*else if (array_is_list($aValue) && array_key_exists((int) $sTag, $aValue)) {
+				} else if (array_is_list($aValue) && array_key_exists((int) $sTag, $aValue)) {
 					$aValue = $aValue[(int) $sTag];
 					$bFind = true;
-				} */else {
+				} else {
 					$aNewValue = array();
 					foreach ($aValue as $aElement) {
 						if ($sTag == '*') //Any tag

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -69,11 +69,7 @@ abstract class JsonCollector extends Collector
 		}
 
 		//**** step 1 : get all parameters from config file
-		$aParamsSourceJson = Utils::GetConfigurationValue(get_class($this), array());
-		if (empty($aParamsSourceJson)) {
-			$aParamsSourceJson = Utils::GetConfigurationValue(strtolower(get_class($this)), array());
-		}
-		Utils::Log(LOG_DEBUG, "aParamsSourceJson [".json_encode($aParamsSourceJson)."]");
+		$aParamsSourceJson = $this->aCollectorConfig;
 		if (isset($aParamsSourceJson["command"])) {
 			$this->sJsonCliCommand = $aParamsSourceJson["command"];
 		}
@@ -141,6 +137,8 @@ abstract class JsonCollector extends Collector
 			Utils::Log(LOG_DEBUG, 'Get params for uploading data file ');
 			if (isset($aParamsSourceJson["jsonpost"])) {
 				$aDataGet = $aParamsSourceJson['jsonpost'];
+			} else {
+				$aDataGet = [];
 			}
 			$iSynchroTimeout = (int)Utils::GetConfigurationValue('itop_synchro_timeout', 600); // timeout in seconds, for a synchro to run
 
@@ -172,7 +170,6 @@ abstract class JsonCollector extends Collector
 
 			return false;
 		}
-
 
 		//**** step 2 : read json file
 		$this->aJson = json_decode($this->sFileJson, true);
@@ -256,6 +253,8 @@ abstract class JsonCollector extends Collector
 							$aValue = $aValue[$sTag];
 							$bFind = true;
 						}
+					} else if (is_array($aValue) && array_key_exists((int) $sTag, $aValue)) {
+						$aValue = $aValue[(int) $sTag];
 					} else {
 						$aNewValue = array();
 						foreach ($aValue as $aElement) {

--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -292,7 +292,7 @@ abstract class JsonCollector extends Collector
 						$aValue = $aValue[$sTag];
 						$bFind = true;
 					}
-				} else if (is_array($aValue) && array_key_exists((int) $sTag, $aValue)) {
+				} else if (array_is_list($aValue) && array_key_exists((int) $sTag, $aValue)) {
 					$aValue = $aValue[(int) $sTag];
 					$bFind = true;
 				} else {

--- a/core/parameters.class.inc.php
+++ b/core/parameters.class.inc.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright (C) 2014 Combodo SARL
 //
-//   This application is free software; you can redistribute it and/or modify	
+//   This application is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.

--- a/core/polyfill.inc.php
+++ b/core/polyfill.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @link https://www.php.net/manual/en/function.array-is-list.php
+ * @see https://www.php.net/manual/en/function.array-is-list.php
  * Make this function available even for (PHP 8 < 8.1.0)
  */
 if (!function_exists("array_is_list")) {

--- a/core/polyfill.inc.php
+++ b/core/polyfill.inc.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @link https://www.php.net/manual/en/function.array-is-list.php
+ * Make this function available even for (PHP 8 < 8.1.0)
+ */
 if (!function_exists("array_is_list")) {
 	function array_is_list(array $array): bool {
 		$i = 0;

--- a/exec.php
+++ b/exec.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright (C) 2014 Combodo SARL
 //
-//   This application is free software; you can redistribute it and/or modify	
+//   This application is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.
@@ -30,6 +30,7 @@ require_once(APPROOT.'core/orchestrator.class.inc.php');
 require_once(APPROOT.'core/sqlcollector.class.inc.php'); // Depends on Orchestrator for settings a minimum version for PHP because of the use of PDO
 require_once(APPROOT.'core/csvcollector.class.inc.php');
 require_once(APPROOT.'core/jsoncollector.class.inc.php');
+require_once(APPROOT.'core/array_polyfill.php');
 
 $aOptionalParams = array(
 	'configure_only'       => 'boolean',

--- a/exec.php
+++ b/exec.php
@@ -30,7 +30,7 @@ require_once(APPROOT.'core/orchestrator.class.inc.php');
 require_once(APPROOT.'core/sqlcollector.class.inc.php'); // Depends on Orchestrator for settings a minimum version for PHP because of the use of PDO
 require_once(APPROOT.'core/csvcollector.class.inc.php');
 require_once(APPROOT.'core/jsoncollector.class.inc.php');
-require_once(APPROOT.'core/array_polyfill.php');
+require_once(APPROOT.'core/polyfill.inc.php');
 
 $aOptionalParams = array(
 	'configure_only'       => 'boolean',

--- a/test/CollectorTest.php
+++ b/test/CollectorTest.php
@@ -53,7 +53,7 @@ XML;
 XML;
 
 		$sPhoneNullifiedSubSection = <<<XML
-<iTopPersonCollec>
+<iTopPersonCollector>
 	<nullified_attributes type="array">
 		<attribute>phone</attribute>
 	</nullified_attributes>

--- a/test/CollectorTest.php
+++ b/test/CollectorTest.php
@@ -52,11 +52,20 @@ XML;
 </iTopPersonCollector_nullified_attributes>
 XML;
 
+		$sPhoneNullifiedSubSection = <<<XML
+<iTopPersonCollec>
+	<nullified_attributes type="array">
+		<attribute>phone</attribute>
+	</nullified_attributes>
+</iTopPersonCollector>
+XML;
+
 		return [
 			'no nullify config' => [ ''],
 			'empty nullify config' => [$sEmptyConfig],
 			'other attributes nullified' => [$sOtherAttributeNulllified],
-			'phone nullified' => [$sPhoneNullifiedSection, true],
+			'phone nullified in iTopPersonCollector_nullified_attributes section' => [$sPhoneNullifiedSection, true],
+			'phone nullified in nullified_attributes sub section' => [$sPhoneNullifiedSubSection, true],
 		];
 	}
 

--- a/test/CsvCollectorTest.php
+++ b/test/CsvCollectorTest.php
@@ -66,8 +66,8 @@ class CsvCollectorTest extends TestCase
 		$this->oMockedLogger->expects($this->exactly(0))
 			->method("Log");
 
-		$oOrgCollector = new iTopPersonCsvCollector();
 		Utils::LoadConfig();
+		$oOrgCollector = new iTopPersonCsvCollector();
 
 		$this->assertTrue($oOrgCollector->Collect());
 
@@ -135,8 +135,8 @@ class CsvCollectorTest extends TestCase
 		$this->oMockedLogger->expects($this->exactly(0))
 			->method("Log");
 
-		$oOrgCollector = new iTopPersonCsvCollector();
 		Utils::LoadConfig();
+		$oOrgCollector = new iTopPersonCsvCollector();
 
 		$this->assertTrue($oOrgCollector->Collect());
 
@@ -159,8 +159,8 @@ class CsvCollectorTest extends TestCase
 		copy(APPROOT."/test/single_csv/csv_errors/$sErrorFile", self::$sCollectorPath."iTopPersonCsvCollector.csv");
 
 		require_once self::$sCollectorPath."iTopPersonCsvCollector.class.inc.php";
-		$orgCollector = new iTopPersonCsvCollector();
 		Utils::LoadConfig();
+		$orgCollector = new iTopPersonCsvCollector();
 
 		if ($sExceptionMsg) {
 			$this->oMockedLogger->expects($this->exactly(2))

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -13,7 +13,7 @@ require_once(APPROOT.'core/collector.class.inc.php');
 require_once(APPROOT.'core/orchestrator.class.inc.php');
 require_once(APPROOT.'core/jsoncollector.class.inc.php');
 require_once(APPROOT.'core/ioexception.class.inc.php');
-require_once(APPROOT.'core/array_polyfill.php');
+require_once(APPROOT.'core/polyfill.inc.php');
 
 class JsonCollectorTest extends TestCase
 {

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -133,8 +133,9 @@ class JsonCollectorTest extends TestCase
 		$this->replaceTranslateRelativePathInParam("/test/single_json/json_error/".$sAdditionalDir);
 
 		require_once self::$sCollectorPath."ITopPersonJsonCollector.class.inc.php";
-		$oOrgCollector = new \ITopPersonJsonCollector();
+
 		\Utils::LoadConfig();
+		$oOrgCollector = new \ITopPersonJsonCollector();
 
 		if ($sExceptionMsg3) {
 			$this->oMockedLogger->expects($this->exactly(3))

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -112,6 +112,8 @@ class JsonCollectorTest extends TestCase
 			"format_json_1" => array("format_json_1"),
 			"format_json_2" => array("format_json_2"),
 			"format_json_3" => array("format_json_3"),
+			"sort of object xpath parsing via a key" => array("format_json_4"),
+			"sort of object xpath parsing via an index" => array("format_json_5"),
 			"first row nullified function" => array("nullified_json_1"),
 			"another row nullified function" => array("nullified_json_2"),
 		);

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -108,16 +108,16 @@ class JsonCollectorTest extends TestCase
 
 	public function OrgCollectorProvider()
 	{
-		return array(
-			"default_value" => array("default_value"),
-			"format_json_1" => array("format_json_1"),
-			"format_json_2" => array("format_json_2"),
-			"format_json_3" => array("format_json_3"),
-			"sort of object xpath parsing via a key" => array("format_json_4"),
-			"sort of object xpath parsing via an index" => array("format_json_5"),
-			"first row nullified function" => array("nullified_json_1"),
-			"another row nullified function" => array("nullified_json_2"),
-		);
+		return [
+			"default_value" => [ "default_value" ],
+			"format_json_1" => [ "format_json_1" ],
+			"format_json_2" => [ "format_json_2" ],
+			"format_json_3" => [ "format_json_3" ],
+			"sort of object xpath parsing via a key" => [ "format_json_4" ],
+			"sort of object xpath parsing via an index" => [ "format_json_5" ],
+			"first row nullified function" => [ "nullified_json_1" ],
+			"another row nullified function" => [ "nullified_json_2" ],
+		];
 	}
 
 	/**
@@ -143,15 +143,15 @@ class JsonCollectorTest extends TestCase
 		if ($sExceptionMsg3) {
 			$this->oMockedLogger->expects($this->exactly(3))
 				->method("Log")
-				->withConsecutive(array(LOG_ERR, $sErrorMsg), array(LOG_ERR, $sExceptionMsg), array(LOG_ERR, $sExceptionMsg3));
+				->withConsecutive([LOG_ERR, $sErrorMsg], [LOG_ERR, $sExceptionMsg], [LOG_ERR, $sExceptionMsg3]);
 		} elseif ($sExceptionMsg) {
 			$this->oMockedLogger->expects($this->exactly(2))
 				->method("Log")
-				->withConsecutive(array(LOG_ERR, $sErrorMsg), array(LOG_ERR, $sExceptionMsg));
+				->withConsecutive([LOG_ERR, $sErrorMsg], [LOG_ERR, $sExceptionMsg]);
 		} elseif ($sErrorMsg) {
 			$this->oMockedLogger->expects($this->exactly(1))
 				->method("Log")
-				->withConsecutive(array(LOG_ERR, $sErrorMsg));
+				->withConsecutive([LOG_ERR, $sErrorMsg]);
 		} else {
 			$this->oMockedLogger->expects($this->exactly(0))
 				->method("Log");
@@ -167,23 +167,23 @@ class JsonCollectorTest extends TestCase
 
 	public function ErrorFileProvider()
 	{
-		return array(
-			"error_json_1" => array(
+		return [
+			"error_json_1" => [
 				"error_json_1",
 				"[ITopPersonJsonCollector] The column \"first_name\", used for reconciliation, is missing in the json file.",
 				"ITopPersonJsonCollector::Collect() got an exception: Missing columns in the json file.",
-			),
-			"error_json_2" => array(
+			],
+			"error_json_2" => [
 				"error_json_2",
 				"[ITopPersonJsonCollector] Failed to find path objects/*/blop until data in json file:  ".APPROOT."/collectors/dataTest.json.",
 				"ITopPersonJsonCollector::Prepare() returned false",
-			),
-			"error_json_3" => array(
+			],
+			"error_json_3" => [
 				"error_json_3",
 				'[ITopPersonJsonCollector] Failed to translate data from JSON file: \''.APPROOT.'/collectors/dataTest.json\'. Reason: Syntax error',
 				"ITopPersonJsonCollector::Prepare() returned false",
-			),
-		);
+			],
+		];
 	}
 
 	public function testFetchWithEmptyJson()

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -244,6 +244,30 @@ JSON;
 		);
 	}
 
+	public function testSearchInItopJsonStructure(){
+		$sJson = <<<JSON
+{
+	"Obj::1": {
+	  "Id": 1,
+	  "Shadok": {
+	    "name": "gabuzomeu"
+	  }
+	}
+}
+JSON;
+
+		$aFieldPaths = [
+			'primary_key' => "*/Id",
+			'name' => "*/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
 	public function testSearchByKeyAndStar2(){
 		$sJson = <<<JSON
 [

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -13,6 +13,7 @@ require_once(APPROOT.'core/collector.class.inc.php');
 require_once(APPROOT.'core/orchestrator.class.inc.php');
 require_once(APPROOT.'core/jsoncollector.class.inc.php');
 require_once(APPROOT.'core/ioexception.class.inc.php');
+require_once(APPROOT.'core/array_polyfill.php');
 
 class JsonCollectorTest extends TestCase
 {

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -199,37 +199,152 @@ class JsonCollectorTest extends TestCase
 		}
 	}
 
-
-	public function SearchFieldValuesProvider(){
-		return [
-			'simple search by key' => [
-				'json' => '{ "Id": "1", "Shadok" : { "name": "gabuzomeu" } }',
-				'aFieldPaths' => [
-					'primary_key' => "Id",
-					'name' => "Shadok/name"
-				]
-			],
-			'search by key using * tag' => [
-				'json' => '[ { "Id": "1", "Shadok" : { "name": "gabuzomeu" } } ]',
-				'aFieldPaths' => [
-					'primary_key' => "*/Id",
-					'name' => "*/Shadok/name"
-				]
-			],
-			'search by key index' => [
-				'json' => '[ { "Id": "1" }, { "Shadok" : { "name": "gabuzomeu" } } ]',
-				'aFieldPaths' => [
-					'primary_key' => "0/Id",
-					'name' => "1/Shadok/name"
-				]
-			],
+	public function testSearchByKey(){
+		$sJson = <<<JSON
+{
+  "Id": "1",
+  "Shadok": {
+    "name": "gabuzomeu"
+  }
+}
+JSON;
+		$aFieldPaths = [
+			'primary_key' => "Id",
+			'name' => "Shadok/name"
 		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
 	}
 
-	/**
-	 * @dataProvider SearchFieldValuesProvider
-	 */
-	public function testSearchFieldValues($sJson, $aTestOnlyFieldsKey)
+	public function testSearchByKeyAndStar(){
+		$sJson = <<<JSON
+[
+  {
+    "Id": "1",
+    "Shadok": {
+      "name": "gabuzomeu"
+    }
+  }
+]
+JSON;
+		$aFieldPaths = [
+			'primary_key' => "*/Id",
+			'name' => "*/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
+	public function testSearchByKeyAndStar2(){
+		$sJson = <<<JSON
+[
+  {
+    "Id": "1"
+  },
+  {
+    "Shadok": {
+      "name": "gabuzomeu"
+    }
+  }
+]
+JSON;
+		$aFieldPaths = [
+			'primary_key' => "*/Id",
+			'name' => "*/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
+	public function testSearchByKeyAndStar3(){
+		$sJson = <<<JSON
+{
+  "XXX": {
+    "Id": "1"
+  },
+  "YYY": {
+    "Shadok": {
+      "name": "gabuzomeu"
+    }
+  }
+}
+JSON;
+		$aFieldPaths = [
+			'primary_key' => "*/Id",
+			'name' => "*/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
+	public function testSearchByKeyAndStar4(){
+		$sJson = <<<JSON
+{
+  "XXX": {
+    "Id": "1"
+  },
+  "YYY": {
+    "Shadok": {
+      "name": "gabuzomeu"
+    }
+  }
+}
+JSON;
+		$aFieldPaths = [
+			'primary_key' => "*/Id",
+			'name' => "*/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
+	public function testSearchByKeyAndIndex(){
+		$sJson = <<<JSON
+[
+  {
+    "Id": "1"
+  },
+  {
+    "Shadok": {
+      "name": "gabuzomeu"
+    }
+  }
+]
+JSON;
+		$aFieldPaths =[
+			'primary_key' => "0/Id",
+			'name' => "1/Shadok/name"
+		];
+
+		$aFetchedFields = $this->CallSearchFieldValues($sJson, $aFieldPaths);
+		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'],
+			$aFetchedFields,
+			var_export($aFetchedFields, true)
+		);
+	}
+
+
+	public function CallSearchFieldValues($sJson, $aFieldPaths)
 	{
 		$this->copy(APPROOT."/test/single_json/common/*");
 		$this->copy(APPROOT."/test/single_json/format_json_1/*");
@@ -250,11 +365,6 @@ class JsonCollectorTest extends TestCase
 		$class = new \ReflectionClass("JsonCollector");
 		$method = $class->getMethod("SearchFieldValues");
 		$method->setAccessible(true);
-		$aFetchFields = $method->invokeArgs($oOrgCollector, [$aData, $aTestOnlyFieldsKey]);
-
-		//$aFetchFields = $oOrgCollector->SearchFieldValues($aData, $aTestOnlyFieldsKey);
-
-		$this->assertEquals(['primary_key' => '1', 'name' => 'gabuzomeu'], $aFetchFields, var_export($aFetchFields, true));
+		return $method->invokeArgs($oOrgCollector, [$aData, $aFieldPaths]);
 	}
-
 }

--- a/test/single_json/format_json_4/dataTest.json
+++ b/test/single_json/format_json_4/dataTest.json
@@ -1,0 +1,44 @@
+{
+  "objects": {
+    "Person": [{"yo": 1,"blop":{
+        "key": "1",
+        "name": "My last name",
+      "first_name": "My first name",
+        "status": "active",
+        "org_id": "1",
+        "email": "my.email@foo.org",
+        "phone": "+00 000 000 000",
+        "notify": "yes",
+        "function": "",
+        "first_nameyo": "My first name"
+    }},{"yo":"2","blop":
+	 {
+        "key": "2",
+        "name": "Picasso",
+       "first_name": "Pablo",
+        "status": "active",
+        "org_id": "3",
+        "org_name": "Demo",
+        "email": "pablo@demo.com",
+        "phone": "",
+        "notify": "yes",
+        "function": "",
+        "first_nameyo": "Pablo"
+     }},{"yo":"3","blop":
+    {
+        "key": "3",
+        "name": "Dali",
+      "first_name": "Salvador",
+        "status": "active",
+        "org_id": "3",
+        "org_name": "Demo",
+        "email": "dali@demo.com",
+        "phone": "",
+        "notify": "yes",
+        "function": "",
+        "first_nameyo": "Salvador"
+    }}]
+  },
+  "code": 0,
+  "message": "Found: 1"
+}

--- a/test/single_json/format_json_4/params.distrib.xml
+++ b/test/single_json/format_json_4/params.distrib.xml
@@ -5,16 +5,16 @@
 		<jsonfile>APPROOT/collectors/dataTest.json</jsonfile>
 		<path>objects/Person/*/blop</path>
 		<fields>
-			<primary_key>Person/key</primary_key>
-			<name>Person/name</name>
-			<status>Person/status</status>
-			<first_name>Person/first_nameyo</first_name>
-			<email>Person/email</email>
-			<phone>Person/phone</phone>
-			<mobile_phone>Person/mobile</mobile_phone>
-			<function>Person/function</function>
-			<employee_number>Person/employeenumber</employee_number>
-			<org_id>Person/org_id</org_id>
+			<primary_key>key</primary_key>
+			<name>name</name>
+			<status>status</status>
+			<first_name>first_nameyo</first_name>
+			<email>email</email>
+			<phone>phone</phone>
+			<mobile_phone>mobile</mobile_phone>
+			<function>function</function>
+			<employee_number>employeenumber</employee_number>
+			<org_id>org_id</org_id>
 		</fields>
 	</itoppersonjsoncollector>
 	<json_placeholders>

--- a/test/single_json/format_json_4/params.distrib.xml
+++ b/test/single_json/format_json_4/params.distrib.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default values for parameters. Do NOT alter this file, use params.local.xml in the conf folder instead -->
+<parameters>
+	<itoppersonjsoncollector>
+		<jsonfile>APPROOT/collectors/dataTest.json</jsonfile>
+		<path>objects/Person/*/blop</path>
+		<fields>
+			<primary_key>Person/key</primary_key>
+			<name>Person/name</name>
+			<status>Person/status</status>
+			<first_name>Person/first_nameyo</first_name>
+			<email>Person/email</email>
+			<phone>Person/phone</phone>
+			<mobile_phone>Person/mobile</mobile_phone>
+			<function>Person/function</function>
+			<employee_number>Person/employeenumber</employee_number>
+			<org_id>Person/org_id</org_id>
+		</fields>
+	</itoppersonjsoncollector>
+	<json_placeholders>
+		<!-- For compatibility with the version 1.1.x of the collector, define the data table names as following:
+		<prefix></prefix>
+		<persons_data_table>synchro_data_PersonAD</persons_data_table>
+		<users_data_table></users_data_table>
+		 -->
+		<prefix>$prefix$</prefix>
+		<persons_data_table>synchro_data_person_1</persons_data_table>
+	</json_placeholders>
+</parameters>

--- a/test/single_json/format_json_5/dataTest.json
+++ b/test/single_json/format_json_5/dataTest.json
@@ -1,0 +1,46 @@
+{
+  "objects": {
+    "Person": [{"yo": 1,"blop":
+    [
+        "gabuzomeu",
+      "1",
+      "My last name",
+      "My first name",
+      "active",
+      "1",
+      "my.email@foo.org",
+      "+00 000 000 000",
+      "yes",
+      "",
+      "My first name"
+    ]},{"yo":"2","blop":[
+      "gabuzomeu",
+      "2",
+      "Picasso",
+      "Pablo",
+      "active",
+      "3",
+      "pablo@demo.com",
+      "",
+      "Demo",
+      "",
+      "yes",
+      "Pablo"
+     ]},{"yo":"3","blop":[
+      "gabuzomeu",
+      "3",
+      "Dali",
+      "Salvador",
+      "active",
+      "3",
+      "dali@demo.com",
+      "",
+      "Demo",
+      "",
+      "yes",
+      "Salvador"
+    ]}]
+  },
+  "code": 0,
+  "message": "Found: 1"
+}

--- a/test/single_json/format_json_5/params.distrib.xml
+++ b/test/single_json/format_json_5/params.distrib.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default values for parameters. Do NOT alter this file, use params.local.xml in the conf folder instead -->
+<parameters>
+	<itoppersonjsoncollector>
+		<jsonfile>APPROOT/collectors/dataTest.json</jsonfile>
+		<path>objects/Person/*/blop</path>
+		<fields>
+			<primary_key>1</primary_key>
+			<name>2</name>
+			<status>4</status>
+			<first_name>3</first_name>
+			<email>6</email>
+			<phone>7</phone>
+			<function>9</function>
+			<org_id>5</org_id>
+		</fields>
+	</itoppersonjsoncollector>
+	<json_placeholders>
+		<!-- For compatibility with the version 1.1.x of the collector, define the data table names as following:
+		<prefix></prefix>
+		<persons_data_table>synchro_data_PersonAD</persons_data_table>
+		<users_data_table></users_data_table>
+		 -->
+		<prefix>$prefix$</prefix>
+		<persons_data_table>synchro_data_person_1</persons_data_table>
+	</json_placeholders>
+</parameters>


### PR DESCRIPTION
Some work has been made for SaaS project. we propose this PR to keep below enhancements:

- refactoring of same code made during constr/init of each collector
- added some logs to have better feedbacks when json reconciliation file is missing
- a json collector fix during collect step when using IsNullified (Hipska's feature)
- have a whole collector XML configuration that also includes IsNullified tuning. at first this IsNullified section was apart from collector conf block. we can support both configurations but may document only the simplest one :

```
<iTopPersonCollector>
....
	<nullified_attributes type="array">
		<attribute>phone</attribute>
	</nullified_attributes>
</iTopPersonCollector>
```

```
<iTopPersonCollector>...</iTopPersonCollector>
<iTopPersonCollector_nullified_attributes type="array">
	<attribute>phone</attribute>
</iTopPersonCollector_nullified_attributes>
```

- enhance json subparsing during collect. we could describe "XPATH" json exploration via * or keys. which is nice for json dictionnary structure. 
```
<parameters>
	<itoppersonjsoncollector>
		<jsonfile>APPROOT/collectors/dataTest.json</jsonfile>
		<path>objects/Person/*/blop</path>
		<fields>
			<primary_key>Person/key</primary_key>
			<name>Person/name</name>
			<status>Person/status</status>
```

now we also accept index (for json list structures) and fix some usecases with *. 
```
<parameters>
	<itoppersonjsoncollector>
		<jsonfile>APPROOT/collectors/dataTest.json</jsonfile>
		<path>objects/Person/*/blop</path>
		<fields>
			<primary_key>tutu/1</primary_key>
			<name>titi/2</name>
```


hopefully all usecases are covered/documented in JsonCollectorTest (testSearchBy methods). including new ones supported and the one we should cover previously (backward compatibility)





