### PR TITLE
N°5710 - Restructure collector - Collection plan enhancement

### DIFF
--- a/core/collectionplan.class.inc.php
+++ b/core/collectionplan.class.inc.php
@@ -60,15 +60,18 @@ abstract class CollectionPlan
 		$aCollectorsLaunchSequence = array_merge($aCollectorsLaunchSequence, $aExtensionsCollectorsLaunchSequence);
 		if (!empty($aCollectorsLaunchSequence)) {
 			// Sort sequence
-			foreach ($aCollectorsLaunchSequence as $iKey => $aCollector) {
+			$aSortedCollectorsLaunchSequence = [];
+			foreach ($aCollectorsLaunchSequence as $aCollector) {
 				if (array_key_exists('rank', $aCollector)) {
 					$aRank[] = $aCollector['rank'];
+					$aSortedCollectorsLaunchSequence[] = $aCollector;
 				} else {
-					unset($aCollectorsLaunchSequence[$iKey]);
 					Utils::Log(LOG_INFO, "> Rank is missing from the launch_sequence of ".$aCollector['name']." It will not be launched.");
 				}
 			}
-			array_multisort($aRank, SORT_ASC, $aCollectorsLaunchSequence);
+			array_multisort($aRank, SORT_ASC, $aSortedCollectorsLaunchSequence);
+
+			return $aSortedCollectorsLaunchSequence;
 		}
 
 		return $aCollectorsLaunchSequence;

--- a/core/collectionplan.class.inc.php
+++ b/core/collectionplan.class.inc.php
@@ -116,6 +116,7 @@ abstract class CollectionPlan
 		}
 
 		$iIndex = 1;
+		$aOrchestratedCollectors = [];
 		foreach ($aCollectorsLaunchSequence as $iKey => $aCollector) {
 			$sCollectorName = $aCollector['name'];
 
@@ -134,9 +135,12 @@ abstract class CollectionPlan
 			// Instantiate collector
 			$oCollector = new $sCollectorName;
 			$oCollector->Init();
-			if ($oCollector->CheckToLaunch()) {
+			if ($oCollector->CheckToLaunch($aOrchestratedCollectors)) {
 				Utils::Log(LOG_INFO, $sCollectorName.' will be launched !');
 				Orchestrator::AddCollector($iIndex++, $sCollectorName);
+				$aOrchestratedCollectors[$sCollectorName] = true;
+			} else {
+				$aOrchestratedCollectors[$sCollectorName] = false;
 			}
 			unset($oCollector);
 		}

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -1004,14 +1004,15 @@ abstract class Collector
 		}
 	}
 
-	/**
-	 * Check if the collector can be launched
-	 *
-	 * @return bool
-	 */
-	public function CheckToLaunch(): bool
-	{
-		return true;
-	}
+    /*
+     * Check if the collector can be launched
+     *
+     * @param $aOrchestratedCollectors = list of collectors already orchestrated
+     *
+     * @return bool
+     */
+    public function CheckToLaunch($aOrchestratedCollectors): bool {
+        return true;
+    }
 
 }

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -1011,7 +1011,7 @@ abstract class Collector
      *
      * @return bool
      */
-    public function CheckToLaunch($aOrchestratedCollectors): bool {
+    public function CheckToLaunch(array $aOrchestratedCollectors): bool {
         return true;
     }
 

--- a/test/CollectionPlanTest.php
+++ b/test/CollectionPlanTest.php
@@ -22,7 +22,7 @@ class CollectionPlanTest extends TestCase
 	private static $sCollectorPath = APPROOT."/collectors/";
 	private $oMockedLogger;
 
-	public function setUp():void
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/CollectionPlanTest.php
+++ b/test/CollectionPlanTest.php
@@ -22,14 +22,14 @@ class CollectionPlanTest extends TestCase
 	private static $sCollectorPath = APPROOT."/collectors/";
 	private $oMockedLogger;
 
-	public function setUp()
+	public function setUp():void
 	{
 		parent::setUp();
 
 		$this->CleanCollectorsFiles();
 	}
 
-	public function tearDown()
+	public function tearDown():void
 	{
 		parent::tearDown();
 		$this->CleanCollectorsFiles();

--- a/test/CollectionPlanTest.php
+++ b/test/CollectionPlanTest.php
@@ -29,7 +29,7 @@ class CollectionPlanTest extends TestCase
 		$this->CleanCollectorsFiles();
 	}
 
-	public function tearDown():void
+	public function tearDown(): void
 	{
 		parent::tearDown();
 		$this->CleanCollectorsFiles();

--- a/test/collectionplan/collectors_files/LegacyCollector.class.inc.php
+++ b/test/collectionplan/collectors_files/LegacyCollector.class.inc.php
@@ -2,7 +2,10 @@
 
 class LegacyCollector extends Collector
 {
-	public function CheckToLaunch($aOrchestratedCollectors): bool
+	/**
+	 * @inheritDoc
+	 */
+	public function CheckToLaunch(array $aOrchestratedCollectors): bool
 	{
 		return false;
 	}

--- a/test/collectionplan/collectors_files/LegacyCollector.class.inc.php
+++ b/test/collectionplan/collectors_files/LegacyCollector.class.inc.php
@@ -2,7 +2,7 @@
 
 class LegacyCollector extends Collector
 {
-	public function CheckToLaunch(): bool
+	public function CheckToLaunch($aOrchestratedCollectors): bool
 	{
 		return false;
 	}


### PR DESCRIPTION
This PR improves the Collector:CheckToLaunch method.

It provides to the collector that needs to check if it can be launched or not, the list of collectors already orchestrated. With this information, it can check its dependencies with other classes and possibly deny the launch if some classes are missing from the collection plan.