### PR TITLE
N°5902 - Handle smoothly empty or header-only CSV source filesby CSV collector

### DIFF
--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -214,7 +214,7 @@ abstract class CSVCollector extends Collector
 			return false;
 		}
 		if ($this->iIdx >= $iCount) {
-			
+
 			return false;
 		}
 

--- a/core/csvcollector.class.inc.php
+++ b/core/csvcollector.class.inc.php
@@ -207,7 +207,14 @@ abstract class CSVCollector extends Collector
 	 */
 	public function Fetch()
 	{
-		if ($this->iIdx >= count($this->aCsvFieldsPerLine)) {
+		$iCount = count($this->aCsvFieldsPerLine);
+		if (($iCount == 0) || (($iCount == 1) && $this->bHasHeader)) {
+			Utils::Log(LOG_ERR, "[".get_class($this)."] CSV file is empty. Data collection stops here.");
+
+			return false;
+		}
+		if ($this->iIdx >= $iCount) {
+			
 			return false;
 		}
 

--- a/test/CsvCollectorTest.php
+++ b/test/CsvCollectorTest.php
@@ -170,8 +170,13 @@ class CsvCollectorTest extends TestCase
 				->method("Log")
 				->withConsecutive(array(LOG_ERR, $sErrorMsg), array(LOG_ERR, $sExceptionMsg));
 		} else {
-			$this->oMockedLogger->expects($this->exactly(0))
-				->method("Log");
+			if ($sErrorMsg) {
+				$this->oMockedLogger->expects($this->exactly(1))
+					->method("Log");
+			} else {
+				$this->oMockedLogger->expects($this->exactly(0))
+					->method("Log");
+			}
 		}
 		try {
 			$bResult = $orgCollector->Collect();
@@ -199,6 +204,16 @@ class CsvCollectorTest extends TestCase
 				"no_email.csv",
 				"[iTopPersonCsvCollector] The column \"email\", used for reconciliation, is missing in the csv file.",
 				"iTopPersonCsvCollector::Collect() got an exception: Missing columns in the csv file.",
+			),
+			"empty csv" => array(
+				"empty_file.csv",
+				"[iTopPersonCsvCollector] CSV file is empty. Data collection stops here.",
+				"",
+			),
+			"empty csv with header" => array(
+				"empty_file_with_header.csv",
+				"[iTopPersonCsvCollector] CSV file is empty. Data collection stops here.",
+				"",
 			),
 			"OK" => array("../nominal/iTopPersonCsvCollector.csv", ""),
 		);

--- a/test/single_csv/csv_errors/empty_file_with_header.csv
+++ b/test/single_csv/csv_errors/empty_file_with_header.csv
@@ -1,0 +1,1 @@
+primary_key;first_name;name;org_id;phone;mobile_phone;employee_number;email;function;status


### PR DESCRIPTION
This is the continuation and enhancement of  PR #15: Update csvcollector to manage empty data csv file.

The PR handles the case of empty files or files with only one line when a header is expected. Next to PR #15, it adds a log entry to inform users that the collector stops because the source file is "empty" and adds 2 PHP Unit tests to make sure the case is properly handled.