### PR TITLE
N°5950 - cleanup code and fix some futurs bugs in php 8.2

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -52,6 +52,7 @@ abstract class Collector
 	protected $sSeparator;
 	protected $aSkippedAttributes;
 	protected $aNullifiedAttributes;
+	protected $sSourceName;
 
 	/**
 	 * Construction
@@ -298,8 +299,10 @@ abstract class Collector
 			if (preg_match($sPattern, $sDataFile, $aMatches)) {
 				$idx = $aMatches[1];
 				$sOutputFile = Utils::GetDataFilePath(get_class($this).'-'.$idx.'.csv');
+
 				Utils::Log(LOG_DEBUG, "Converting '$sDataFile' to '$sOutputFile'...");
-				ini_set('auto_detect_line_endings', true);
+				//only usefull of files from old mac system deprecated in php 8.1
+				//ini_set('auto_detect_line_endings', true);
 
 				$hCSV = fopen($sDataFile, 'r');
 				if ($hCSV === false) {
@@ -529,7 +532,6 @@ abstract class Collector
 			$bResult = $this->Prepare();
 			if ($bResult) {
 				$idx = 0;
-				$aColumns = array();
 				$aHeaders = null;
 				while ($aRow = $this->Fetch()) {
 					if ($aHeaders == null) {
@@ -568,6 +570,7 @@ abstract class Collector
 					Utils::Log(LOG_WARNING, "Invalid column '$sHeader', will be ignored.");
 				}
 			} else {
+
 				$this->aCSVHeaders[] = $sHeader;
 			}
 		}
@@ -819,6 +822,7 @@ abstract class Collector
 				if ($this->AttributeIsOptional($aAttr['attcode'])) {
 					Utils::Log(LOG_INFO, "Skipping optional attribute {$aAttr['attcode']}.");
 					$this->aSkippedAttributes[] = $aAttr['attcode']; // record that this attribute was skipped
+
 				} else {
 					// Update only the SynchroAttributes which are really different
 					// Ignore read-only fields

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -299,10 +299,7 @@ abstract class Collector
 			if (preg_match($sPattern, $sDataFile, $aMatches)) {
 				$idx = $aMatches[1];
 				$sOutputFile = Utils::GetDataFilePath(get_class($this).'-'.$idx.'.csv');
-
 				Utils::Log(LOG_DEBUG, "Converting '$sDataFile' to '$sOutputFile'...");
-				//only usefull of files from old mac system deprecated in php 8.1
-				//ini_set('auto_detect_line_endings', true);
 
 				$hCSV = fopen($sDataFile, 'r');
 				if ($hCSV === false) {

--- a/core/parameters.class.inc.php
+++ b/core/parameters.class.inc.php
@@ -25,6 +25,7 @@ class InvalidParameterException extends Exception
 class Parameters
 {
 	protected $aData = null;
+	protected $sParametersFile;
 
 	public function __construct($sInputFile = null)
 	{

--- a/core/sqlcollector.class.inc.php
+++ b/core/sqlcollector.class.inc.php
@@ -33,6 +33,7 @@ abstract class SQLCollector extends Collector
 {
 	protected $oDB;
 	protected $oStatement;
+	protected $idx;
 
 	/**
 	 * Initalization
@@ -144,6 +145,7 @@ abstract class SQLCollector extends Collector
 	public function Fetch()
 	{
 		if ($aData = $this->oStatement->fetch(PDO::FETCH_ASSOC)) {
+
 			foreach ($this->aSkippedAttributes as $sCode) {
 				unset($aData[$sCode]);
 			}

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -573,7 +573,7 @@ class Utils
 
 		$iElapsed = time() - $iBeginTime;
 		if (0 === $iCode) {
-			Utils::Log(LOG_INFO, "elapsed:${iElapsed}s output: $sStdOut");
+			Utils::Log(LOG_INFO, "elapsed:{$iElapsed}s output: $sStdOut");
 
 			return $sStdOut;
 		} else {

--- a/toolkit/dump_tasks.php
+++ b/toolkit/dump_tasks.php
@@ -97,12 +97,7 @@ if ($sTaskName == '*') {
 					$aCurrentTaskDefinition['database_table_name'] = "";
 				}
 
-				if (defined('JSON_PRETTY_PRINT')) {
-					echo json_encode($aCurrentTaskDefinition, JSON_PRETTY_PRINT);
-				} else {
-					$sDefinition = json_encode($aCurrentTaskDefinition);
-					echo Utils::JSONPrettyPrint($sDefinition)."\n";
-				}
+				echo json_encode($aCurrentTaskDefinition, JSON_PRETTY_PRINT);
 			}
 		} else {
 			echo "Sorry, no SynchroDataSource named '$sTaskName' found in iTop.\n";


### PR DESCRIPTION
small improvements :
-add missing variable declarations
-remove code deprecated in php 8.1 and useless (used only for old Mac system)
-remove test on JSON_PRETTY_PRINT (defined since php 5.3) 
-fix a comment