### PR TITLE
N°5996 - During creation of csv file, in function lookup remove warning if initial field is empty

### DIFF
--- a/core/lookuptable.class.inc.php
+++ b/core/lookuptable.class.inc.php
@@ -118,6 +118,7 @@ class LookupTable
 			$this->InitLineMappings($aLineData, array_merge($aLookupFields, array($sDestField)));
 		} else {
 			$iPos = $this->aFieldsPos[$sDestField];
+			//skip search if field is empty
 			if ($bSkipIfEmpty && $iPos !== null && $aLineData[$iPos] === '' ) {
 				return false;
 			}

--- a/core/lookuptable.class.inc.php
+++ b/core/lookuptable.class.inc.php
@@ -111,12 +111,16 @@ class LookupTable
 	 *
 	 * @return bool true if the mapping succeeded, false otherwise
 	 */
-	public function Lookup(&$aLineData, $aLookupFields, $sDestField, $iLineIndex)
+	public function Lookup(&$aLineData, $aLookupFields, $sDestField, $iLineIndex, $bSkipIfEmpty = false )
 	{
 		$bRet = true;
 		if ($iLineIndex == 0) {
 			$this->InitLineMappings($aLineData, array_merge($aLookupFields, array($sDestField)));
 		} else {
+			$iPos = $this->aFieldsPos[$sDestField];
+			if ($bSkipIfEmpty && $iPos !== null && $aLineData[$iPos] === '' ) {
+				return false;
+			}
 			$aLookupKey = array();
 			foreach ($aLookupFields as $sField) {
 				$iPos = $this->aFieldsPos[$sField];

--- a/core/lookuptable.class.inc.php
+++ b/core/lookuptable.class.inc.php
@@ -24,6 +24,15 @@ class LookupTable
 	protected $bCaseSensitive;
 	protected $bIgnoreMappingErrors;
 	protected $sReturnAttCode;
+	protected static $oRestClient;
+
+	/**
+	 * @param RestClient $oRestClient
+	 */
+	public static function SetRestClient(RestClient $oRestClient)
+	{
+		static::$oRestClient = $oRestClient;
+	}
 
 	/**
 	 * Initialization of a LookupTable, based on an OQL query in iTop
@@ -48,7 +57,11 @@ class LookupTable
 			throw new Exception("Invalid OQL query: '$sOQL'. Expecting a query starting with 'SELECT xxx'");
 		}
 		$sClass = $aMatches[1];
-		$oRestClient = new RestClient();
+		if(static::$oRestClient != null) {
+			$oRestClient = static::$oRestClient;
+		} else {
+			$oRestClient = new RestClient();
+		}
 		$aRestFields = $aKeyFields;
 		if ($this->sReturnAttCode !== 'id') {
 			// If the return attcode is not the ID of the object, add it to the list of the required fields

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -29,6 +29,7 @@ class Utils
 	static public $oCollector = "";
 	static protected $oConfig = null;
 	static protected $aConfigFiles = array();
+	static protected $iMockLogLevel = LOG_ERR;
 
 	static protected $oMockedLogger;
 
@@ -136,7 +137,7 @@ class Utils
 	{
 		//testing only LOG_ERR
 		if (self::$oMockedLogger) {
-			if ($iPriority <= self::$iConsoleLogLevel && $iPriority <= LOG_ERR) {
+			if ($iPriority <= self::$iConsoleLogLevel && $iPriority <= self::$iMockLogLevel) {
 				var_dump($sMessage);
 				self::$oMockedLogger->Log($iPriority, $sMessage);
 			}
@@ -213,9 +214,10 @@ class Utils
 		$oClient->Create("EventIssue", $aFields, 'create event issue from collector $sCollectorName execution.');
 	}
 
-	static public function MockLog($oMockedLogger)
+	static public function MockLog($oMockedLogger,  $iMockLogLevel)
 	{
 		self::$oMockedLogger = $oMockedLogger;
+		self::$iMockLogLevel = $iMockLogLevel;
 	}
 
 	/**

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -214,7 +214,7 @@ class Utils
 		$oClient->Create("EventIssue", $aFields, 'create event issue from collector $sCollectorName execution.');
 	}
 
-	static public function MockLog($oMockedLogger,  $iMockLogLevel)
+	static public function MockLog($oMockedLogger,  $iMockLogLevel = LOG_ERR)
 	{
 		self::$oMockedLogger = $oMockedLogger;
 		self::$iMockLogLevel = $iMockLogLevel;

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -137,7 +137,7 @@ class Utils
 	{
 		//testing only LOG_ERR
 		if (self::$oMockedLogger) {
-			if ($iPriority <= self::$iConsoleLogLevel && $iPriority <= self::$iMockLogLevel) {
+			if ($iPriority <= self::$iMockLogLevel) {
 				var_dump($sMessage);
 				self::$oMockedLogger->Log($iPriority, $sMessage);
 			}

--- a/test/LookupTest.php
+++ b/test/LookupTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace UnitTestFiles\Test;
+
+use iTopPersonCollector;
+use LookupTable;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Exception;
+use RestClient;
+use Utils;
+
+@define('APPROOT', dirname(__FILE__, 2).'/');
+
+require_once(APPROOT.'core/parameters.class.inc.php');
+require_once(APPROOT.'core/utils.class.inc.php');
+require_once(APPROOT.'core/collector.class.inc.php');
+require_once(APPROOT.'core/orchestrator.class.inc.php');
+require_once(APPROOT.'core/ioexception.class.inc.php');
+require_once(APPROOT.'core/lookuptable.class.inc.php');
+require_once(APPROOT.'core/restclient.class.inc.php');
+
+class LookupTest extends TestCase
+{
+	private $oRestClient;
+	private $oLookupTable;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->oRestClient = $this->createMock(RestClient::class);
+
+		LookupTable::SetRestClient($this->oRestClient);
+
+		$this->oMockedLogger = $this->createMock("UtilsLogger");
+		Utils::MockLog($this->oMockedLogger, LOG_DEBUG);
+
+	}
+
+    public function tearDown(): void
+	{
+		parent::tearDown();
+
+	}
+
+	/*
+	 * test function lookup from class LookupTable
+	 * */
+	public function LookupProvider()
+	{
+		return [
+			'normal' => [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+								'aData' => ['OSVersion::61' => ['code'=>0,
+																				"message"=>"",
+																				"class"=>"OSVersion",
+																				"key"=>"61",
+																				"fields"=>["osfamily_id"=>"Microsoft Windows 10",
+																					"osversion_id"=>"10.0.19044"]
+																			]
+												],
+								'aLineData' =>["1","test_normal",'Microsoft Windows 10',"10.0.19044"],
+								'aLookupFields' => ["osfamily_id","osversion_id"],
+								'sDestField' => 'osversion_id',
+								'iFieldIndex' => 3,
+								'bSkipIfEmpty' => false,
+								'bCaseSensitive' => false,
+								'bIgnoreMappingErrors' => false,
+								'sExpectedRes' => true,
+								'sExpectedErrorType' => '',
+								'sExpectedErrorMessage' => '',
+								'sExpectedValue' => 61 ],
+			'casesensitive_true' => [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+				'aData' => ['OSVersion::61' => ['code'=>0,
+																"message"=>"",
+																"class"=>"OSVersion",
+																"key"=>"61",
+																"fields"=>["osfamily_id"=>"Microsoft Windows 10",
+																	"osversion_id"=>"10.0.19044"]
+															]
+								],
+				'aLineData' =>["1","test_normal",'Microsoft Windows 10',"10.0.19044"],
+				'aLookupFields' => ["osfamily_id","osversion_id"],
+				'sDestField' => 'osversion_id',
+				'iFieldIndex' => 3,
+				'bSkipIfEmpty' => false,
+				'bCaseSensitive' => true,
+				'bIgnoreMappingErrors' => false,
+				'sExpectedRes' => true,
+				'sExpectedErrorType' => '',
+				'sExpectedErrorMessage' => '',
+				'sExpectedValue' => 61 ],
+		'casesensitive_true_error' => [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+														'aData' => ['OSVersion::61' => ['code'=>0,
+																		"message"=>"",
+																		"class"=>"OSVersion",
+																		"key"=>"61",
+																		"fields"=>["osfamily_id"=>"microsoft Windows 10",
+																						"osversion_id"=>"10.0.19044"]
+														]
+					],
+					'aLineData' =>["1","test_normal",'Microsoft Windows 10',"10.0.19044"],
+					'aLookupFields' => ["osfamily_id","osversion_id"],
+					'sDestField' => 'osversion_id',
+					'iFieldIndex' => 3,
+					'bSkipIfEmpty' => false,
+					'bCaseSensitive' => true,
+					'bIgnoreMappingErrors' => false,
+					'sExpectedRes' => false,
+					'sExpectedErrorType' => LOG_WARNING,
+					'sExpectedErrorMessage' => 'No mapping found with key: \'Microsoft Windows 10_10.0.19044\', \'osversion_id\' will be set to zero.',
+					'sExpectedValue' => 61 ],
+			"error_fieldNotFound_warning" =>   [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+								'aData' => ['OSVersion::61' => ['code'=>0,
+													"message"=>"",
+													"class"=>"OSVersion",
+													"key"=>"61",
+													"fields"=>["osfamily_id"=>"Microsoft Windows 10",
+															"osversion_id"=>"10.0.19044"]
+												]
+								],
+								'aLineData' =>["1","test_normal",'Microsoft Windows 10',"10.0.190445"],
+								'aLookupFields' => ["osfamily_id","osversion_id"],
+								'sDestField' => 'osversion_id',
+								'iFieldIndex' => 3,
+								'bSkipIfEmpty' => false,
+								'bCaseSensitive' => false,
+								'bIgnoreMappingErrors' => false,
+								'sExpectedRes' =>'',
+								'sExpectedErrorType' => LOG_WARNING,
+								'sExpectedErrorMessage' => 'No mapping found with key: \'microsoft windows 10_10.0.190445\', \'osversion_id\' will be set to zero.',
+								'sExpectedValue' => 2 ],
+			"error_fieldNotFound_debug" =>  [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+											'aData' => ['OSVersion::61' => ['code'=>0,
+															"message"=>"",
+															"class"=>"OSVersion",
+															"key"=>"61",
+															"fields"=>["osfamily_id"=>"Microsoft Windows 10",
+																			"osversion_id"=>"10.0.19044"]
+											]
+								],
+								'aLineData' =>["1","test_normal",'Microsoft Windows 10',"10.0.190445"],
+								'aLookupFields' => ["osfamily_id","osversion_id"],
+								'sDestField' => 'osversion_id',
+								'iFieldIndex' => 3,
+								'bSkipIfEmpty' => false,
+								'bCaseSensitive' => false,
+								'bIgnoreMappingErrors' => true,
+								'sExpectedRes' =>'',
+								'sExpectedErrorType' => LOG_DEBUG,
+								'sExpectedErrorMessage' => 'No mapping found with key: \'microsoft windows 10_10.0.190445\', \'osversion_id\' will be set to zero.',
+								'sExpectedValue' => 2 ],
+			"emptyfield" =>   [	'aFirstLine' => ["primary_key","name","osfamily_id","osversion_id"],
+											'aData' => ['OSVersion::61' => ['code'=>0,
+															"message"=>"",
+															"class"=>"OSVersion",
+															"key"=>"61",
+															"fields"=>["osfamily_id"=>"Microsoft Windows 10",
+																		"osversion_id"=>"10.0.19044"]
+											]
+								],
+								'aLineData' =>["1","test_normal",'Microsoft Windows 10',''],
+								'aLookupFields' => ["osfamily_id","osversion_id"],
+								'sDestField' => 'osversion_id',
+								'iFieldIndex' => 3,
+								'bSkipIfEmpty' => true,
+								'bCaseSensitive' => false,
+								'bIgnoreMappingErrors' => false,
+								'sExpectedRes' =>'',
+								'sExpectedErrorType' => '',
+								'sExpectedErrorMessage' => '',
+								'sExpectedValue' => 2 ],
+		];
+	}
+
+	/**
+	 * @dataProvider LookupProvider
+	 */
+	public function testLookup($aFirstLine,  $aData, $aLineData, $aLookupFields, $sDestField, $iFieldIndex, $bSkipIfEmpty, $bCaseSensitive, $bIgnoreMappingErrors, $sExpectedRes, $sExpectedErrorType, $sExpectedErrorMessage, $sExpectedValue)
+	{
+		$this->oRestClient->expects($this->once())
+									->method('Get')
+									->with('OSVersion', 'SELECT OSVersion', 'osfamily_id,osversion_id')
+									->willReturn([
+											'code' => 0,
+											'objects' => $aData
+											])  ;
+		$this->oLookupTable = new LookupTable('SELECT OSVersion', $aLookupFields,$bCaseSensitive, $bIgnoreMappingErrors );
+
+		if($sExpectedErrorType != ''){
+			$this->oMockedLogger->expects($this->once())
+									->method('Log')
+									->with($sExpectedErrorType, $sExpectedErrorMessage) ;
+		} else {
+			$this->oMockedLogger->expects($this->never())
+				->method('Log') ;
+
+		}
+		$this->oLookupTable->Lookup($aFirstLine, $aLookupFields, $sDestField, 0);
+		$sRes = $this->oLookupTable->Lookup($aLineData, $aLookupFields, $sDestField, 1, $bSkipIfEmpty);
+
+
+		$this->assertEquals( $sExpectedRes,$sRes );
+
+		if ($sRes) {
+			$this->assertEquals($sExpectedValue,$aLineData[$iFieldIndex]);
+		}
+}
+}


### PR DESCRIPTION
During creation of csv file, in function lookup remove warning if initial field is empty.

Example :
During the collection process, in my initial data, oslicence_id is empty. I have a lookup on this field. This lookup does not find any data and it's normal. But in the logs, there is a warning :
[Warning]       No mapping found with key: '47_', 'oslicence_id' will be set to zero.

I want to remove this warning

