### PR TITLE
N°6012 - Use authentication via tokens to reach iTop

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -4,7 +4,9 @@
   <itop_url>https://localhost/iTop</itop_url>
   <itop_login>admin</itop_login>
   <itop_password>admin</itop_password>
-  
+  <rest-token/>
+  <token/>
+
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console
    0 : System wide emergency errors only (LOG_EMERG)
@@ -68,11 +70,11 @@
   <NAME_OF_THE_OPTION1>VALUE_OF_THE_OPTION1</NAME_OF_THE_OPTION1>
   <NAME_OF_THE_OPTION2>VALUE_OF_THE_OPTION2</NAME_OF_THE_OPTION2>
   etc...
-  
+
   Where NAME_OF_THE_OPTIONx and VALUE_OF_THE_OPTIONx are either:
   - The numeric value of the option
   - or the string representation of the corresponding PHP "define" (case sensitive)
-  
+
   The four examples below are equivalent:
    <CURLOPT_SSLVERSION>CURL_SSLVERSION_TLSv1_2</CURLOPT_SSLVERSION>
   or
@@ -81,7 +83,7 @@
    <32>CURL_SSLVERSION_TLSv1_2</32>
   or
    <32>6</32>
-   
+
   Since in PHP we have:
   define ('CURLOPT_SSLVERSION', 32);
   define ('CURL_SSLVERSION_TLSv1_2', 6);

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -6,6 +6,7 @@
   <itop_password>admin</itop_password>
   <itop_rest_token/>
   <itop_token/>
+  <itop_login_mode/>
 
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -4,7 +4,6 @@
   <itop_url>https://localhost/iTop</itop_url>
   <itop_login>admin</itop_login>
   <itop_password>admin</itop_password>
-  <itop_rest_token/>
   <itop_token/>
   <itop_login_mode/>
 

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -4,8 +4,8 @@
   <itop_url>https://localhost/iTop</itop_url>
   <itop_login>admin</itop_login>
   <itop_password>admin</itop_password>
-  <rest-token/>
-  <token/>
+  <itop_rest_token/>
+  <itop_token/>
 
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console

--- a/core/callitopservice.class.inc.php
+++ b/core/callitopservice.class.inc.php
@@ -10,12 +10,8 @@ class CallItopService
 
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').$sUri;
 
-
 		$aData = array_merge(
-			array(
-				'auth_user' => Utils::GetConfigurationValue('itop_login', ''),
-				'auth_pwd' => Utils::GetConfigurationValue('itop_password', ''),
-			),
+			Utils::GetCredentials(),
 			$aAdditionalData
 		);
 

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -680,7 +680,8 @@ abstract class Collector
 				'charset' => $this->GetCharset(),
 			);
 
-			$sResult = self::CallItopViaHttp('/synchro/synchro_import.php?login_mode=form',
+			$sLoginform = Utils::GetLoginForm();
+			$sResult = self::CallItopViaHttp("/synchro/synchro_import.php?login_mode=$sLoginform",
 				$aData);
 
 			// Read the status code from the last line
@@ -704,7 +705,8 @@ abstract class Collector
 			$aData['max_chunk_size'] = $iMaxChunkSize;
 		}
 
-		$sResult = self::CallItopViaHttp('/synchro/synchro_exec.php?login_mode=form',
+		$sLoginform = Utils::GetLoginForm();
+		$sResult = self::CallItopViaHttp("/synchro/synchro_exec.php?login_mode=$sLoginform",
 			$aData);
 
 		$iErrorsCount = 0;

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -680,7 +680,7 @@ abstract class Collector
 				'charset' => $this->GetCharset(),
 			);
 
-			$sLoginform = Utils::GetLoginForm();
+			$sLoginform = Utils::GetLoginMode();
 			$sResult = self::CallItopViaHttp("/synchro/synchro_import.php?login_mode=$sLoginform",
 				$aData);
 
@@ -705,7 +705,7 @@ abstract class Collector
 			$aData['max_chunk_size'] = $iMaxChunkSize;
 		}
 
-		$sLoginform = Utils::GetLoginForm();
+		$sLoginform = Utils::GetLoginMode();
 		$sResult = self::CallItopViaHttp("/synchro/synchro_exec.php?login_mode=$sLoginform",
 			$aData);
 

--- a/core/dopostrequestservice.class.inc.php
+++ b/core/dopostrequestservice.class.inc.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @since 1.3.0
+ */
+class DoPostRequestService
+{
+	public function DoPostRequest($sUrl, $aData, $sOptionnalHeaders = null, &$aResponseHeaders = null, $aCurlOptions = []){
+		return null;
+	}
+}

--- a/core/dopostrequestservice.class.inc.php
+++ b/core/dopostrequestservice.class.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @since 1.3.0
+ * @since 1.3.0 N°6012
  */
 class DoPostRequestService
 {

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -112,7 +112,12 @@ class RestClient
 	{
 		$aData = Utils::GetCredentials();
 		$aData['json_data'] = json_encode($aOperation);
-		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/webservices/rest.php?login_mode=form&version='.$sVersion;
+		$sLoginform = Utils::GetLoginForm();
+		$sUrl = sprintf('%s/webservices/rest.php?login_mode=%s&version=%s',
+			Utils::GetConfigurationValue('itop_url', ''),
+			$sLoginform,
+			$sVersion
+		);
 		$aHeaders = array();
 		$aCurlOptions = Utils::GetCurlOptions();
 		$response = Utils::DoPostRequest($sUrl, $aData, '', $aHeaders, $aCurlOptions);

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -110,9 +110,7 @@ class RestClient
 
 	protected static function ExecOperation($aOperation, $sVersion = '1.0')
 	{
-		$aData = array();
-		$aData['auth_user'] = Utils::GetConfigurationValue('itop_login', '');
-		$aData['auth_pwd'] = Utils::GetConfigurationValue('itop_password', '');
+		$aData = Utils::GetCredentials();
 		$aData['json_data'] = json_encode($aOperation);
 		$sUrl = Utils::GetConfigurationValue('itop_url', '').'/webservices/rest.php?login_mode=form&version='.$sVersion;
 		$aHeaders = array();

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -112,7 +112,7 @@ class RestClient
 	{
 		$aData = Utils::GetCredentials();
 		$aData['json_data'] = json_encode($aOperation);
-		$sLoginform = Utils::GetLoginForm();
+		$sLoginform = Utils::GetLoginMode();
 		$sUrl = sprintf('%s/webservices/rest.php?login_mode=%s&version=%s',
 			Utils::GetConfigurationValue('itop_url', ''),
 			$sLoginform,

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -305,13 +305,6 @@ class Utils
 			];
 		}
 
-		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
-		if (strlen($sToken) > 0){
-			return [
-				'auth_token' => $sToken
-			];
-		}
-
 		return [
 			'auth_user' => Utils::GetConfigurationValue('itop_login', ''),
 			'auth_pwd' => Utils::GetConfigurationValue('itop_password', ''),

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -299,14 +299,14 @@ class Utils
 	 */
 	static public function GetCredentials() : array {
 		$sToken = Utils::GetConfigurationValue('itop_token', '');
-		if (! empty($sToken)){
+		if (strlen($sToken) > 0){
 			return [
 				'token' => $sToken
 			];
 		}
 
 		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
-		if (! empty($sToken)){
+		if (strlen($sToken) > 0){
 			return [
 				'rest-token' => $sToken
 			];
@@ -323,17 +323,17 @@ class Utils
 	 */
 	static public function GetLoginMode() : string {
 		$sLoginform = Utils::GetConfigurationValue('itop_login_mode', '');
-		if (! empty($sLoginform)){
+		if (strlen($sLoginform) > 0){
 			return $sLoginform;
 		}
 
 		$sToken = Utils::GetConfigurationValue('itop_token', '');
-		if (! empty($sToken)){
+		if (strlen($sToken) > 0){
 			return 'token';
 		}
 
 		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
-		if (! empty($sToken)){
+		if (strlen($sToken) > 0){
 			return 'rest-token';
 		}
 

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -321,8 +321,8 @@ class Utils
 	/**
 	 * @since 1.3.0 N°6012
 	 */
-	static public function GetLoginForm() : string {
-		$sLoginform = Utils::GetConfigurationValue('itop_login_form', '');
+	static public function GetLoginMode() : string {
+		$sLoginform = Utils::GetConfigurationValue('itop_login_mode', '');
 		if (! empty($sLoginform)){
 			return $sLoginform;
 		}

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -32,6 +32,10 @@ class Utils
 	static protected $aConfigFiles = array();
 
 	static protected $oMockedLogger;
+
+	/**
+	 * @since 1.3.0 N°6012
+	 */
 	static protected $oMockedDoPostRequestService;
 
 	static public function SetProjectName($sProjectName)
@@ -220,6 +224,11 @@ class Utils
 		self::$oMockedLogger = $oMockedLogger;
 	}
 
+	/**
+	 * @param DoPostRequestService|null $oMockedDoPostRequestService
+	 * @since 1.3.0 N°6012
+	 * @return void
+	 */
 	static public function MockDoPostRequestService($oMockedDoPostRequestService)
 	{
 		self::$oMockedDoPostRequestService = $oMockedDoPostRequestService;
@@ -286,7 +295,7 @@ class Utils
 	}
 
 	/**
-	 * @since 1.3.0
+	 * @since 1.3.0 N°6012
 	 */
 	static public function GetCredentials() : array {
 		$sToken = Utils::GetConfigurationValue('token', '');

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -301,14 +301,14 @@ class Utils
 		$sToken = Utils::GetConfigurationValue('itop_token', '');
 		if (strlen($sToken) > 0){
 			return [
-				'token' => $sToken
+				'auth_token' => $sToken
 			];
 		}
 
 		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
 		if (strlen($sToken) > 0){
 			return [
-				'rest-token' => $sToken
+				'auth_token' => $sToken
 			];
 		}
 
@@ -330,11 +330,6 @@ class Utils
 		$sToken = Utils::GetConfigurationValue('itop_token', '');
 		if (strlen($sToken) > 0){
 			return 'token';
-		}
-
-		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
-		if (strlen($sToken) > 0){
-			return 'rest-token';
 		}
 
 		return 'form';

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -298,14 +298,14 @@ class Utils
 	 * @since 1.3.0 N°6012
 	 */
 	static public function GetCredentials() : array {
-		$sToken = Utils::GetConfigurationValue('token', '');
+		$sToken = Utils::GetConfigurationValue('itop_token', '');
 		if (! empty($sToken)){
 			return [
 				'token' => $sToken
 			];
 		}
 
-		$sToken = Utils::GetConfigurationValue('rest-token', '');
+		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
 		if (! empty($sToken)){
 			return [
 				'rest-token' => $sToken
@@ -316,6 +316,28 @@ class Utils
 			'auth_user' => Utils::GetConfigurationValue('itop_login', ''),
 			'auth_pwd' => Utils::GetConfigurationValue('itop_password', ''),
 		];
+	}
+
+	/**
+	 * @since 1.3.0 N°6012
+	 */
+	static public function GetLoginForm() : string {
+		$sLoginform = Utils::GetConfigurationValue('itop_login_form', '');
+		if (! empty($sLoginform)){
+			return $sLoginform;
+		}
+
+		$sToken = Utils::GetConfigurationValue('itop_token', '');
+		if (! empty($sToken)){
+			return 'token';
+		}
+
+		$sToken = Utils::GetConfigurationValue('itop_rest_token', '');
+		if (! empty($sToken)){
+			return 'rest-token';
+		}
+
+		return 'form';
 	}
 
 	/**

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace UnitTestFiles\Test;
+
+use PHPUnit\Framework\TestCase;
+use CallItopService;
+use Utils;
+use DoPostRequestService;
+
+@define('APPROOT', dirname(__FILE__, 2).'/');
+
+require_once(APPROOT.'core/utils.class.inc.php');
+require_once(APPROOT.'core/callitopservice.class.inc.php');
+require_once(APPROOT.'core/dopostrequestservice.class.inc.php');
+require_once(APPROOT.'core/parameters.class.inc.php');
+
+class CallItopServiceTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+	}
+
+	public function GetCredentialsProvider(){
+		return [
+			'login/password (nominal)' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2'
+				],
+				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2']
+			],
+			'legacy rest-token' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'rest-token' => 'admin3',
+				],
+				'aExpectedCredentials' => ['rest-token'=> 'admin3']
+			],
+			'new token' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'token' => 'admin4',
+				],
+				'aExpectedCredentials' => ['token'=> 'admin4']
+			],
+			'new token over legacy one' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'rest-token' => 'admin3',
+					'token' => 'admin4',
+				],
+				'aExpectedCredentials' => ['token'=> 'admin4']
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider GetCredentialsProvider
+	 */
+	public function testCallItopViaHttp($aParameters, $aExpectedCredentials){
+		$oParametersMock = $this->createMock(\Parameters::class);
+		$oParametersMock->expects($this->atLeast(1))
+			->method('Get')
+			->will($this->returnCallback(
+				function($sKey, $aDefaultValue) use ($aParameters) {
+					if (array_key_exists($sKey, $aParameters)){
+						return $aParameters[$sKey];
+					}
+					return $aDefaultValue;
+				}
+			));
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, $oParametersMock);
+
+		$oMockedDoPostRequestService = $this->createMock(DoPostRequestService::class);
+		Utils::MockDoPostRequestService($oMockedDoPostRequestService);
+
+		$uri = 'http://itop.org';
+		$aAdditionalData = ['gabu' => 'zomeu'];
+		$oMockedDoPostRequestService->expects($this->once())
+			->method('DoPostRequest')
+			->with($uri, array_merge($aExpectedCredentials, $aAdditionalData ))
+		;
+
+		$oCallItopService = new CallItopService();
+		$oCallItopService->CallItopViaHttp($uri, $aAdditionalData);
+	}
+
+}

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -41,14 +41,6 @@ class CallItopServiceTest extends TestCase
 				],
 				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2']
 			],
-			'legacy rest-token' => [
-				'aParameters' => [
-					'itop_login' => 'admin1',
-					'itop_password' => 'admin2',
-					'itop_rest_token' => 'admin3',
-				],
-				'aExpectedCredentials' => ['auth_token'=> 'admin3']
-			],
 			'new token' => [
 				'aParameters' => [
 					'itop_login' => 'admin1',

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -2,10 +2,10 @@
 
 namespace UnitTestFiles\Test;
 
-use PHPUnit\Framework\TestCase;
 use CallItopService;
-use Utils;
 use DoPostRequestService;
+use PHPUnit\Framework\TestCase;
+use Utils;
 
 @define('APPROOT', dirname(__FILE__, 2).'/');
 
@@ -45,7 +45,7 @@ class CallItopServiceTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
+					'itop_rest_token' => 'admin3',
 				],
 				'aExpectedCredentials' => ['rest-token'=> 'admin3']
 			],
@@ -53,7 +53,7 @@ class CallItopServiceTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'token' => 'admin4',
+					'itop_token' => 'admin4',
 				],
 				'aExpectedCredentials' => ['token'=> 'admin4']
 			],
@@ -61,8 +61,8 @@ class CallItopServiceTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
-					'token' => 'admin4',
+					'itop_rest_token' => 'admin3',
+					'itop_token' => 'admin4',
 				],
 				'aExpectedCredentials' => ['token'=> 'admin4']
 			],

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -21,6 +21,17 @@ class CallItopServiceTest extends TestCase
 		parent::setUp();
 	}
 
+	public function tearDown(): void
+	{
+		parent::tearDown();
+		Utils::MockDoPostRequestService(null);
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, null);
+	}
+
+
 	public function GetCredentialsProvider(){
 		return [
 			'login/password (nominal)' => [

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -47,7 +47,7 @@ class CallItopServiceTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_rest_token' => 'admin3',
 				],
-				'aExpectedCredentials' => ['rest-token'=> 'admin3']
+				'aExpectedCredentials' => ['auth_token'=> 'admin3']
 			],
 			'new token' => [
 				'aParameters' => [
@@ -55,7 +55,7 @@ class CallItopServiceTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['auth_token'=> 'admin4']
 			],
 			'new token over legacy one' => [
 				'aParameters' => [
@@ -64,7 +64,7 @@ class CallItopServiceTest extends TestCase
 					'itop_rest_token' => 'admin3',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['auth_token'=> 'admin4']
 			],
 		];
 	}

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -73,14 +73,14 @@ class RestTest extends TestCase
 				'aExpectedCredentials' => ['token'=> 'admin4'],
 				'url' => 'URI/webservices/rest.php?login_mode=token&version=1.0'
 			],
-			'configured login_form' => [
+			'configured login_mode' => [
 				'aParameters' => [
 					'itop_url' => 'URI',
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
 					'itop_rest_token' => 'admin3',
 					'itop_token' => 'admin4',
-					'itop_login_form' => 'newloginform',
+					'itop_login_mode' => 'newloginform',
 				],
 				'aExpectedCredentials' => ['token'=> 'admin4'],
 				'url' => 'URI/webservices/rest.php?login_mode=newloginform&version=1.0'

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -2,10 +2,10 @@
 
 namespace UnitTestFiles\Test;
 
+use DoPostRequestService;
 use PHPUnit\Framework\TestCase;
 use RestClient;
 use Utils;
-use DoPostRequestService;
 
 @define('APPROOT', dirname(__FILE__, 2).'/');
 
@@ -39,35 +39,51 @@ class RestTest extends TestCase
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2'
 				],
-				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2']
+				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2'],
+				'url' => 'URI/webservices/rest.php?login_mode=form&version=1.0'
 			],
 			'legacy rest-token' => [
 				'aParameters' => [
 					'itop_url' => 'URI',
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
+					'itop_rest_token' => 'admin3',
 				],
-				'aExpectedCredentials' => ['rest-token'=> 'admin3']
+				'aExpectedCredentials' => ['rest-token'=> 'admin3'],
+				'url' => 'URI/webservices/rest.php?login_mode=rest-token&version=1.0'
 			],
 			'new token' => [
 				'aParameters' => [
 					'itop_url' => 'URI',
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'token' => 'admin4',
+					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'url' => 'URI/webservices/rest.php?login_mode=token&version=1.0'
 			],
 			'new token over legacy one' => [
 				'aParameters' => [
 					'itop_url' => 'URI',
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
-					'token' => 'admin4',
+					'itop_rest_token' => 'admin3',
+					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'url' => 'URI/webservices/rest.php?login_mode=token&version=1.0'
+			],
+			'configured login_form' => [
+				'aParameters' => [
+					'itop_url' => 'URI',
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'itop_rest_token' => 'admin3',
+					'itop_token' => 'admin4',
+					'itop_login_form' => 'newloginform',
+				],
+				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'url' => 'URI/webservices/rest.php?login_mode=newloginform&version=1.0'
 			],
 		];
 	}
@@ -75,7 +91,7 @@ class RestTest extends TestCase
 	/**
 	 * @dataProvider GetCredentialsProvider
 	 */
-	public function testCallItopViaHttp($aParameters, $aExpectedCredentials){
+	public function testCallItopViaHttp($aParameters, $aExpectedCredentials, $sExpectedUrl){
 		$oParametersMock = $this->createMock(\Parameters::class);
 		$oParametersMock->expects($this->atLeast(1))
 			->method('Get')
@@ -95,7 +111,6 @@ class RestTest extends TestCase
 		$oMockedDoPostRequestService = $this->createMock(DoPostRequestService::class);
 		Utils::MockDoPostRequestService($oMockedDoPostRequestService);
 
-		$uri = 'URI/webservices/rest.php?login_mode=form&version=1.0';
 		$aListParams = array(
 			'operation'     => 'list_operations', // operation code
 			'output_fields' => '*', // list of fields to show in the results (* or a,b,c)
@@ -103,7 +118,7 @@ class RestTest extends TestCase
 		$aAdditionalData = ['json_data' => json_encode($aListParams)];
 		$oMockedDoPostRequestService->expects($this->once())
 			->method('DoPostRequest')
-			->with($uri, array_merge($aExpectedCredentials, $aAdditionalData ))
+			->with($sExpectedUrl, array_merge($aExpectedCredentials, $aAdditionalData ))
 			->willReturn(json_encode(['retcode' => 0]));
 		;
 

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace UnitTestFiles\Test;
+
+use PHPUnit\Framework\TestCase;
+use RestClient;
+use Utils;
+use DoPostRequestService;
+
+@define('APPROOT', dirname(__FILE__, 2).'/');
+
+require_once(APPROOT.'core/utils.class.inc.php');
+require_once(APPROOT.'core/restclient.class.inc.php');
+require_once(APPROOT.'core/dopostrequestservice.class.inc.php');
+require_once(APPROOT.'core/parameters.class.inc.php');
+
+class RestTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+	}
+
+	public function GetCredentialsProvider(){
+		return [
+			'login/password (nominal)' => [
+				'aParameters' => [
+					'itop_url' => 'URI',
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2'
+				],
+				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2']
+			],
+			'legacy rest-token' => [
+				'aParameters' => [
+					'itop_url' => 'URI',
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'rest-token' => 'admin3',
+				],
+				'aExpectedCredentials' => ['rest-token'=> 'admin3']
+			],
+			'new token' => [
+				'aParameters' => [
+					'itop_url' => 'URI',
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'token' => 'admin4',
+				],
+				'aExpectedCredentials' => ['token'=> 'admin4']
+			],
+			'new token over legacy one' => [
+				'aParameters' => [
+					'itop_url' => 'URI',
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'rest-token' => 'admin3',
+					'token' => 'admin4',
+				],
+				'aExpectedCredentials' => ['token'=> 'admin4']
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider GetCredentialsProvider
+	 */
+	public function testCallItopViaHttp($aParameters, $aExpectedCredentials){
+		$oParametersMock = $this->createMock(\Parameters::class);
+		$oParametersMock->expects($this->atLeast(1))
+			->method('Get')
+			->will($this->returnCallback(
+				function($sKey, $aDefaultValue) use ($aParameters) {
+					if (array_key_exists($sKey, $aParameters)){
+						return $aParameters[$sKey];
+					}
+					return $aDefaultValue;
+				}
+			));
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, $oParametersMock);
+
+		$oMockedDoPostRequestService = $this->createMock(DoPostRequestService::class);
+		Utils::MockDoPostRequestService($oMockedDoPostRequestService);
+
+		$uri = 'URI/webservices/rest.php?login_mode=form&version=1.0';
+		$aListParams = array(
+			'operation'     => 'list_operations', // operation code
+			'output_fields' => '*', // list of fields to show in the results (* or a,b,c)
+		);
+		$aAdditionalData = ['json_data' => json_encode($aListParams)];
+		$oMockedDoPostRequestService->expects($this->once())
+			->method('DoPostRequest')
+			->with($uri, array_merge($aExpectedCredentials, $aAdditionalData ))
+			->willReturn(json_encode(['retcode' => 0]));
+		;
+
+		$oRestClient = new RestClient();
+		$this->assertEquals(['retcode' => 0], $oRestClient->ListOperations());
+	}
+
+}

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -21,6 +21,16 @@ class RestTest extends TestCase
 		parent::setUp();
 	}
 
+	public function tearDown(): void
+	{
+		parent::tearDown();
+		Utils::MockDoPostRequestService(null);
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, null);
+	}
+
 	public function GetCredentialsProvider(){
 		return [
 			'login/password (nominal)' => [

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -42,16 +42,6 @@ class RestTest extends TestCase
 				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2'],
 				'url' => 'URI/webservices/rest.php?login_mode=form&version=1.0'
 			],
-			'legacy rest-token' => [
-				'aParameters' => [
-					'itop_url' => 'URI',
-					'itop_login' => 'admin1',
-					'itop_password' => 'admin2',
-					'itop_rest_token' => 'admin3',
-				],
-				'aExpectedCredentials' => ['rest-token'=> 'admin3'],
-				'url' => 'URI/webservices/rest.php?login_mode=rest-token&version=1.0'
-			],
 			'new token' => [
 				'aParameters' => [
 					'itop_url' => 'URI',
@@ -59,7 +49,7 @@ class RestTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'aExpectedCredentials' => ['auth_token'=> 'admin4'],
 				'url' => 'URI/webservices/rest.php?login_mode=token&version=1.0'
 			],
 			'new token over legacy one' => [
@@ -70,7 +60,7 @@ class RestTest extends TestCase
 					'itop_rest_token' => 'admin3',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'aExpectedCredentials' => ['auth_token'=> 'admin4'],
 				'url' => 'URI/webservices/rest.php?login_mode=token&version=1.0'
 			],
 			'configured login_mode' => [
@@ -82,7 +72,7 @@ class RestTest extends TestCase
 					'itop_token' => 'admin4',
 					'itop_login_mode' => 'newloginform',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4'],
+				'aExpectedCredentials' => ['auth_token'=> 'admin4'],
 				'url' => 'URI/webservices/rest.php?login_mode=newloginform&version=1.0'
 			],
 		];

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -124,7 +124,7 @@ class UtilsTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_rest_token' => 'admin3',
 				],
-				'aExpectedCredentials' => ['rest-token'=> 'admin3']
+				'aExpectedCredentials' => ['auth_token'=> 'admin3']
 			],
 			'new token' => [
 				'aParameters' => [
@@ -132,7 +132,7 @@ class UtilsTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['auth_token'=> 'admin4']
 			],
 			'new token over legacy one' => [
 				'aParameters' => [
@@ -141,7 +141,7 @@ class UtilsTest extends TestCase
 					'itop_rest_token' => 'admin3',
 					'itop_token' => 'admin4',
 				],
-				'aExpectedCredentials' => ['token'=> 'admin4']
+				'aExpectedCredentials' => ['auth_token'=> 'admin4']
 			],
 		];
 	}
@@ -201,15 +201,7 @@ class UtilsTest extends TestCase
 				],
 				'sExpectedLoginMode' => 'form'
 			],
-			'legacy rest-token' => [
-				'aParameters' => [
-					'itop_login' => 'admin1',
-					'itop_password' => 'admin2',
-					'itop_rest_token' => 'admin3',
-				],
-				'sExpectedLoginMode' => 'rest-token'
-			],
-			'new token' => [
+			'authent-token v2' => [
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -170,9 +170,9 @@ class UtilsTest extends TestCase
 	}
 
 	/**
-	 * @dataProvider GetLoginFormProvider
+	 * @dataProvider GetLoginModeProvider
 	 */
-	public function testGetLoginForm($aParameters, $sExpectedLoginForm){
+	public function testGetLoginForm($aParameters, $sExpectedLoginMode){
 		$oParametersMock = $this->createMock(\Parameters::class);
 		$oParametersMock->expects($this->atLeast(1))
 			->method('Get')
@@ -189,17 +189,17 @@ class UtilsTest extends TestCase
 		$reflection->setAccessible(true);
 		$reflection->setValue(null, $oParametersMock);
 
-		$this->assertEquals($sExpectedLoginForm, Utils::GetLoginForm());
+		$this->assertEquals($sExpectedLoginMode, Utils::GetLoginMode());
 	}
 
-	public function GetLoginFormProvider(){
+	public function GetLoginModeProvider(){
 		return [
 			'login/password (nominal)' => [
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2'
 				],
-				'sExpectedLoginForm' => 'form'
+				'sExpectedLoginMode' => 'form'
 			],
 			'legacy rest-token' => [
 				'aParameters' => [
@@ -207,7 +207,7 @@ class UtilsTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_rest_token' => 'admin3',
 				],
-				'sExpectedLoginForm' => 'rest-token'
+				'sExpectedLoginMode' => 'rest-token'
 			],
 			'new token' => [
 				'aParameters' => [
@@ -215,7 +215,7 @@ class UtilsTest extends TestCase
 					'itop_password' => 'admin2',
 					'itop_token' => 'admin4',
 				],
-				'sExpectedLoginForm' => 'token'
+				'sExpectedLoginMode' => 'token'
 			],
 			'new token over legacy one' => [
 				'aParameters' => [
@@ -224,17 +224,17 @@ class UtilsTest extends TestCase
 					'itop_rest_token' => 'admin3',
 					'itop_token' => 'admin4',
 				],
-				'sExpectedLoginForm' => 'token'
+				'sExpectedLoginMode' => 'token'
 			],
-			'login_form over others' => [
+			'itop_login_mode over others' => [
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
 					'itop_rest-token' => 'admin3',
 					'itop_token' => 'admin4',
-					'itop_login_form' => 'newloginform',
+					'itop_login_mode' => 'newloginform',
 				],
-				'sExpectedLoginForm' => 'newloginform'
+				'sExpectedLoginMode' => 'newloginform'
 			],
 		];
 	}

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -122,7 +122,7 @@ class UtilsTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
+					'itop_rest_token' => 'admin3',
 				],
 				'aExpectedCredentials' => ['rest-token'=> 'admin3']
 			],
@@ -130,7 +130,7 @@ class UtilsTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'token' => 'admin4',
+					'itop_token' => 'admin4',
 				],
 				'aExpectedCredentials' => ['token'=> 'admin4']
 			],
@@ -138,8 +138,8 @@ class UtilsTest extends TestCase
 				'aParameters' => [
 					'itop_login' => 'admin1',
 					'itop_password' => 'admin2',
-					'rest-token' => 'admin3',
-					'token' => 'admin4',
+					'itop_rest_token' => 'admin3',
+					'itop_token' => 'admin4',
 				],
 				'aExpectedCredentials' => ['token'=> 'admin4']
 			],
@@ -168,4 +168,76 @@ class UtilsTest extends TestCase
 
 		$this->assertEquals($aExpectedCredentials, Utils::GetCredentials());
 	}
+
+	/**
+	 * @dataProvider GetLoginFormProvider
+	 */
+	public function testGetLoginForm($aParameters, $sExpectedLoginForm){
+		$oParametersMock = $this->createMock(\Parameters::class);
+		$oParametersMock->expects($this->atLeast(1))
+			->method('Get')
+			->will($this->returnCallback(
+				function($sKey, $aDefaultValue) use ($aParameters) {
+					if (array_key_exists($sKey, $aParameters)){
+						return $aParameters[$sKey];
+					}
+					return $aDefaultValue;
+				}
+			));
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, $oParametersMock);
+
+		$this->assertEquals($sExpectedLoginForm, Utils::GetLoginForm());
+	}
+
+	public function GetLoginFormProvider(){
+		return [
+			'login/password (nominal)' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2'
+				],
+				'sExpectedLoginForm' => 'form'
+			],
+			'legacy rest-token' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'itop_rest_token' => 'admin3',
+				],
+				'sExpectedLoginForm' => 'rest-token'
+			],
+			'new token' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'itop_token' => 'admin4',
+				],
+				'sExpectedLoginForm' => 'token'
+			],
+			'new token over legacy one' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'itop_rest_token' => 'admin3',
+					'itop_token' => 'admin4',
+				],
+				'sExpectedLoginForm' => 'token'
+			],
+			'login_form over others' => [
+				'aParameters' => [
+					'itop_login' => 'admin1',
+					'itop_password' => 'admin2',
+					'itop_rest-token' => 'admin3',
+					'itop_token' => 'admin4',
+					'itop_login_form' => 'newloginform',
+				],
+				'sExpectedLoginForm' => 'newloginform'
+			],
+		];
+	}
+
+
 }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -118,14 +118,6 @@ class UtilsTest extends TestCase
 				],
 				'aExpectedCredentials' => ['auth_user'=> 'admin1', 'auth_pwd'=>'admin2']
 			],
-			'legacy rest-token' => [
-				'aParameters' => [
-					'itop_login' => 'admin1',
-					'itop_password' => 'admin2',
-					'itop_rest_token' => 'admin3',
-				],
-				'aExpectedCredentials' => ['auth_token'=> 'admin3']
-			],
 			'new token' => [
 				'aParameters' => [
 					'itop_login' => 'admin1',

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -17,6 +17,16 @@ class UtilsTest extends TestCase
 		parent::setUp();
 	}
 
+	public function tearDown(): void
+	{
+		parent::tearDown();
+		Utils::MockDoPostRequestService(null);
+
+		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
+		$reflection->setAccessible(true);
+		$reflection->setValue(null, null);
+	}
+
 	public function ComputeCurlOptionsProvider(){
 		return [
 			'nominal usecase: constant key/ constant int value' => [


### PR DESCRIPTION
collector-base communicate with iTop through login/password (rest/synchro). this PR aims at passing tokens instead to authenticate. for that purpose iTop should have authent-token extension.

here are the XML configurations covered:

* authentication via login/password

<?xml version="1.0" encoding="UTF-8"?>
<!-- Default values for parameters. Do NOT alter this file, use params.local.xml instead -->
<parameters>
  <itop_url>https://localhost/iTop</itop_url>
  <itop_login>admin1</itop_login>
  <itop_password>admin2</itop_password>

POST parameters will include 
['auth_user'=> 'admin1', 'auth_pwd2'=>'admin']

in URL login_form remains at value 'form'.

 * authentication via token (next version of authent-token)

<?xml version="1.0" encoding="UTF-8"?>
<!-- Default values for parameters. Do NOT alter this file, use params.local.xml instead -->
<parameters>
  <itop_url>https://localhost/iTop</itop_url>
  <itop_login>admin1</itop_login>
  <itop_password>admin2</itop_password>
  <itop_token>admin_token</token>

POST parameters will include  ['token'=> 'admin_token']
in URL login_form is changed to value 'token'.

 * authentication via token (first version of authent-token)

<?xml version="1.0" encoding="UTF-8"?>
<!-- Default values for parameters. Do NOT alter this file, use params.local.xml instead -->
<parameters>
  <itop_url>https://localhost/iTop</itop_url>
  <itop_login>admin1</itop_login>
  <itop_password>admin2</itop_password>
  <itop_rest_token>admin_token</rest-token>

POST parameters will include  ['rest-token'=> 'admin_token']
in URL login_form is changed to value 'rest-token'.

To override login-form in URL you still can do it via XML itop_login_form parameter.
