### PR TITLE
N°6109 Fix datatable name removed in dump_task

### DIFF
--- a/toolkit/dump_tasks.php
+++ b/toolkit/dump_tasks.php
@@ -92,11 +92,6 @@ if ($sTaskName == '*') {
 				$aCurrentTaskDefinition['user_id'] = '$synchro_user$';
 				$aCurrentTaskDefinition['notify_contact_id'] = '$contact_to_notify$';
 
-
-				if (isset($aCurrentTaskDefinition['database_table_name'])) {
-					$aCurrentTaskDefinition['database_table_name'] = "";
-				}
-
 				echo json_encode($aCurrentTaskDefinition, JSON_PRETTY_PRINT);
 			}
 		} else {


### PR DESCRIPTION
This is causing issue when creating the datasynchro on iTop with a custom datatable name, then dumping it and using the JSON in a collector.

Regression introduced in 595abed