### PR TITLE
Update the definition of optional attributes when present

### DIFF
--- a/test/CollectorTest.php
+++ b/test/CollectorTest.php
@@ -139,4 +139,135 @@ CSV;
 			}
 		}
 	}
+	
+	/**
+	 * @dataProvider providerUpdateSDSAttributes
+	 * @param array $aExpectedAttrDef
+	 * @param array $aSynchroAttrDef
+	 * @param bool $bWillUpdate
+	 */
+	public function testUpdateSDSAttributes($aExpectedAttrDef, $aSynchroAttrDef, bool $bWillUpdate)
+	{
+	    $this->copy(APPROOT."/test/collector/attribute_isnullified/*");
+	    require_once APPROOT."/core/restclient.class.inc.php";
+	    require_once self::$sCollectorPath."iTopPersonCollector.class.inc.php";
+	    $oCollector = new iTopPersonCollector();
+	    $oMockClient = $this->CreateMock('RestClient');
+	    $oMockClient->expects($this->exactly($bWillUpdate ? 1 : 0))->method("Update")->willReturn(['code' => 0]);
+	    
+	    $bRet = $this->InvokeNonPublicMethod(get_class($oCollector), 'UpdateSDSAttributes', $oCollector, [$aExpectedAttrDef, $aSynchroAttrDef, '', $oMockClient]);
+	   
+	    $this->assertTrue($bRet);
+	}
+	
+	public function providerUpdateSDSAttributes()
+	{
+	    return [
+	        'no difference' => [
+	            'aExpectedAttrDef' => [
+	                [
+	                    "attcode" => "name",
+	                    "update" => "1",
+	                    "reconcile" => "1",
+	                    "update_policy" => "master_locked",
+	                    "finalclass" => "SynchroAttribute",
+	                    "friendlyname" => "name",
+	                ],
+	            ],
+	            'aSynchroAttrDef' => [
+	                [
+	                    "attcode" => "name",
+	                    "update" => "1",
+	                    "reconcile" => "1",
+	                    "update_policy" => "master_locked",
+	                    "finalclass" => "SynchroAttribute",
+	                    "friendlyname" => "name",
+	                ],
+	            ],
+	            'bWillUpdate' => false,
+	        ],
+	        'reconcile is different' => [
+    	    'aExpectedAttrDef' => [
+    	        [
+    	            "attcode" => "name",
+    	            "update" => "1",
+    	            "reconcile" => "1",
+    	            "update_policy" => "master_locked",
+    	            "finalclass" => "SynchroAttribute",
+    	            "friendlyname" => "name",
+    	        ],
+    	    ],
+    	    'aSynchroAttrDef' => [
+    	        [
+    	            "attcode" => "name",
+    	            "update" => "1",
+    	            "reconcile" => "0", // Difference here
+    	            "update_policy" => "master_locked",
+    	            "finalclass" => "SynchroAttribute",
+    	            "friendlyname" => "name",
+    	        ],
+    	    ],
+	        'bWillUpdate' => true,
+	       ],
+	        'update policy is different on OPTIONAL field' => [
+	            'aExpectedAttrDef' => [
+	                [
+	                    "attcode" => "optional", // Note: 'optional' is an attribute considered as "optional" in this test
+	                    "update" => "1",
+	                    "reconcile" => "1",
+	                    "update_policy" => "master_locked",
+	                    "finalclass" => "SynchroAttribute",
+	                    "friendlyname" => "optional",
+	                ],
+	            ],
+	            'aSynchroAttrDef' => [
+	                [
+	                    "attcode" => "optional",
+	                    "update" => "1",
+	                    "reconcile" => "1",
+	                    "update_policy" => "master_unlocked",  // Difference here
+	                    "finalclass" => "SynchroAttribute",
+	                    "friendlyname" => "optional",
+	                ],
+	            ],
+	            'bWillUpdate' => true,
+	        ],
+	        'OPTIONAL field actually missing' => [
+	            'aExpectedAttrDef' => [
+	            ],
+	            'aSynchroAttrDef' => [
+	                [
+	                    "attcode" => "optional",
+	                    "update" => "1",
+	                    "reconcile" => "1",
+	                    "update_policy" => "master_unlocked",  // Difference here
+	                    "finalclass" => "SynchroAttribute",
+	                    "friendlyname" => "optional",
+	                ],
+	            ],
+	            'bWillUpdate' => false,
+	        ],
+	    ];
+	}
+
+	/**
+	 * @param string $sObjectClass for example DBObject::class
+	 * @param string $sMethodName
+	 * @param object $oObject
+	 * @param array $aArgs
+	 *
+	 * @return mixed method result
+	 *
+	 * @throws \ReflectionException
+	 *
+	 * @since 2.7.4 3.0.0
+	 */
+	public function InvokeNonPublicMethod($sObjectClass, $sMethodName, $oObject, $aArgs)
+	{
+	    $class = new \ReflectionClass($sObjectClass);
+	    $method = $class->getMethod($sMethodName);
+	    $method->setAccessible(true);
+	    
+	    return $method->invokeArgs($oObject, $aArgs);
+	}
 }

--- a/test/collector/attribute_isnullified/iTopPersonCollector.class.inc.php
+++ b/test/collector/attribute_isnullified/iTopPersonCollector.class.inc.php
@@ -24,4 +24,13 @@ class iTopPersonCollector extends Collector
 
 		return null;
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @see Collector::AttributeIsOptional()
+	 */
+	public function AttributeIsOptional($sAttCode)
+	{
+	    return ($sAttCode === 'optional');
+	}
 }


### PR DESCRIPTION
When an attribute was considered as "Optional" by a collector (to take into account the variability of the data models), the synchro definition of this attribute was not updated by the collector.

This pull request addresses this problem.