### PR TITLE
Add some synchro data source parameters to conf/params.distrib.xml

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -7,6 +7,10 @@
   <itop_token/>
   <itop_login_mode/>
 
+  <!-- Parameters for the synchro data sources -->
+  <contact_to_notify/>
+  <synchro_user/>
+	
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console
    0 : System wide emergency errors only (LOG_EMERG)


### PR DESCRIPTION
The definitions of the contact_to_notify and synchro_user placeholders are not set in the config file today. Even if their absence is handled by the orchestrator, keeping them in the file would help user to realize that they exist and can be changed.