### PR TITLE
N°6773 Log the synchro error message in debug mode

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -733,6 +733,7 @@ abstract class Collector
 				}
 			} else {
 				Utils::Log(LOG_ERR, "Synchronization of data source '{$this->sSourceName}' failed.");
+				Utils::Log(LOG_DEBUG, $sResult);
 				$this->sErrorMessage .= $sResult;
 				$iErrorsCount = 1;
 			}

--- a/core/orchestrator.class.inc.php
+++ b/core/orchestrator.class.inc.php
@@ -264,7 +264,6 @@ class Orchestrator
 			Utils::SetCollector($oCollector, "Synchronize");
 			$bResult = $oCollector->Synchronize();
 			if (!$bResult) {
-				Utils::Log(LOG_DEBUG, $oCollector->GetErrorMessage());
 				if ($bStopOnError) {
 					break;
 				} else {

--- a/core/orchestrator.class.inc.php
+++ b/core/orchestrator.class.inc.php
@@ -264,6 +264,7 @@ class Orchestrator
 			Utils::SetCollector($oCollector, "Synchronize");
 			$bResult = $oCollector->Synchronize();
 			if (!$bResult) {
+				Utils::Log(LOG_DEBUG, $oCollector->GetErrorMessage());
 				if ($bStopOnError) {
 					break;
 				} else {


### PR DESCRIPTION
It was hard to find out the actual error message returned when this is the only message:

> Synchronization of data source 'xxxx' failed.

So now if you set `console_log_level` to debug, you will also see the actual returned message by `synchro_exec.php`.