### PR TITLE
N°7338 - Use "itop_login" as fallback value if no "synchro_user" defined in parameters

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -104,6 +104,6 @@
 
   <!-- The email address of an existing contact in iTop, to be notified in case of error during the synchronization -->
   <contact_to_notify></contact_to_notify>
-  <!-- iTop user set as allowed to run synchronization. It is highly recommended to use the same as itop_login -->
+  <!-- iTop user set as allowed to run synchronization. By default, it is the same as itop_login -->
   <synchro_user></synchro_user>
 </parameters>

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -104,6 +104,6 @@
 
   <!-- The email address of an existing contact in iTop, to be notified in case of error during the synchronization -->
   <contact_to_notify></contact_to_notify>
-  <!-- iTop user set as allowed to run synchronization. By default, it is the same as itop_login -->
+  <!-- iTop user set as allowed to run synchronization. It is highly recommended to use the same as itop_login. By default, it is the same as itop_login -->
   <synchro_user></synchro_user>
 </parameters>

--- a/core/orchestrator.class.inc.php
+++ b/core/orchestrator.class.inc.php
@@ -172,7 +172,7 @@ class Orchestrator
 				Utils::Log(LOG_ERR, "Unable to find the contact with email = '$sEmailToNotify'. No contact to notify will be defined.");
 			}
 		}
-		$sSynchroUser = Utils::GetConfigurationValue('synchro_user', '');
+		$sSynchroUser = Utils::GetConfigurationValue('synchro_user', Utils::GetConfigurationValue('itop_login', ''));
 		$aPlaceholders['$synchro_user$'] = 0;
 		if ($sSynchroUser != '') {
 			$oRestClient = new RestClient();


### PR DESCRIPTION
Add useful default value for `synchro_user` so there is no need to define the same username in most cases.