### PR TITLE
N°3709 - Add the possibility to use an other date format than the default one

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -106,4 +106,5 @@
   <contact_to_notify></contact_to_notify>
   <!-- iTop user set as allowed to run synchronization. It is highly recommended to use the same as itop_login -->
   <synchro_user></synchro_user>
+  <date_format>Y-m-d</date_format>
 </parameters>

--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -106,5 +106,6 @@
   <contact_to_notify></contact_to_notify>
   <!-- iTop user set as allowed to run synchronization. It is highly recommended to use the same as itop_login -->
   <synchro_user></synchro_user>
+  <!-- date format in collected data -->
   <date_format>Y-m-d</date_format>
 </parameters>

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -685,6 +685,7 @@ abstract class Collector
 				'output' => $sOutput,
 				'csvdata' => file_get_contents($sDataFile),
 				'charset' => $this->GetCharset(),
+                'date_format' => Utils::GetConfigurationValue('date_format', 'Y-m-d')
 			);
 
 			$sLoginform = Utils::GetLoginMode();


### PR DESCRIPTION
By adding 
`  <date_format>d/m/Y</date_format>`
in <parameters> tag