### PR TITLE
N°7339 - Improve error handling when user has no permission to write in data directory

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -603,26 +603,32 @@ abstract class Collector
 		fputcsv($this->aCSVFile[$this->iFileIndex], $aData, $this->sSeparator);
 	}
 
+	/**
+	 * @return true
+	 * @throws IOException When file cannot be opened.
+	 */
 	protected function OpenCSVFile()
 	{
-		$bResult = true;
 		if ($this->MustProcessBeforeSynchro()) {
 			$sDataFile = Utils::GetDataFilePath(get_class($this).'.raw-'.(1 + $this->iFileIndex).'.csv');
 		} else {
 			$sDataFile = Utils::GetDataFilePath(get_class($this).'-'.(1 + $this->iFileIndex).'.csv');
 		}
-		$this->aCSVFile[$this->iFileIndex] = fopen($sDataFile, 'wb');
+		$this->aCSVFile[$this->iFileIndex] = @fopen($sDataFile, 'wb');
 
 		if ($this->aCSVFile[$this->iFileIndex] === false) {
-			Utils::Log(LOG_ERR, "Unable to open the file '$sDataFile' for writing.");
-			$bResult = false;
+			throw new IOException("Unable to open the file '$sDataFile' for writing.");
 		} else {
 			Utils::Log(LOG_INFO, "Writing to file '$sDataFile'.");
 		}
 
-		return $bResult;
+		return true;
 	}
 
+	/**
+	 * @return true
+	 * @throws IOException When file cannot be opened.
+	 */
 	protected function NextCSVFile()
 	{
 		if ($this->iFileIndex !== null) {


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix

## Symptom
```
PHP Warning:  fopen(data/TeemIpDiscoveryIPv4Collector-1.csv): Failed to open stream: Permission denied in core/collector.class.inc.php on line 614
[2024-02-12 09:54:41]	[Error]	Unable to open the file 'data/TeemIpDiscoveryIPv4Collector-1.csv' for writing.
PHP Fatal error:  Uncaught TypeError: fputcsv(): Argument #1 ($stream) must be of type resource, bool given in core/collector.class.inc.php:589
Stack trace:
#0 core/collector.class.inc.php(589): fputcsv(false, Array, ';')
#1 core/collector.class.inc.php(555): Collector->AddHeader(Array)
#2 collectors/src/TeemIpDiscoveryIPv4Collector.class.inc.php(682): Collector->Collect('1000')
#3 core/orchestrator.class.inc.php(237): TeemIpDiscoveryIPv4Collector->Collect('1000', true)
#4 exec.php(123): Orchestrator->Collect(Array, '1000', true)
#5 {main}
  thrown in core/collector.class.inc.php on line 589
```

So the collector crashes.

## Reproduction procedure
<!--
Remove this section only if it's NOT a bug.

Otherwise, explain step by step how to reproduce the issue on a standard iTop Community.

If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. With teemip-ip-discovery-collector 3.1.2 <!-- Put complete collector version (eg. itop-collector-base 1.3.2) -->
2. With PHP 8.1.27 <!-- Put complete PHP version (eg. 8.1.24) -->
3. Targeting TeemIP version 3.1.4-2311 <!-- Put complete iTop version (eg. iTop 3.0.2-1) -->
4. Run collector as a user without permission to write the collector data folder.


## Cause

Running the collector as a different user who doesn't have write permissions to the `data` directory and missing error handling.

## Proposed solution

Return an `IOException` instead of just logging the message, so it can be catched within the `Collector::Collect` method and shut down correctly.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
