### PR TITLE
N°7482 - Ensure to dump source definition only when on debug

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -514,9 +514,10 @@ abstract class Collector
 								Utils::Log(LOG_INFO, "Ok, the Synchro Data Source '{$this->sSourceName}' exists in iTop and is up to date");
 							} else {
 								Utils::Log(LOG_INFO, "The Synchro Data Source definition for '{$this->sSourceName}' must be updated in iTop.");
-								// For debugging...
-								file_put_contents(APPROOT.'data/tmp-'.get_class($this).'-orig.txt', print_r($aExpectedSourceDefinition, true));
-								file_put_contents(APPROOT.'data/tmp-'.get_class($this).'-itop.txt', print_r($aCurrentSourceDefinition, true));
+								if (LOG_DEBUG <= Utils::$iConsoleLogLevel) {
+									file_put_contents(APPROOT.'data/tmp-'.get_class($this).'-orig.txt', print_r($aExpectedSourceDefinition, true));
+									file_put_contents(APPROOT.'data/tmp-'.get_class($this).'-itop.txt', print_r($aCurrentSourceDefinition, true));
+								}
 								$bResult = $this->UpdateSynchroDataSource($aExpectedSourceDefinition, $this->GetName());
 							}
 						}


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Objective

Don't dump the data source definitions if not debugging, so no cluttering of the data directory.

## Proposed solution

Only dump the files for debugging when the console log level is `LOG_DEBUG`.


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
