### PR TITLE
Fix lookuptable ignore errors

### DIFF
--- a/core/lookuptable.class.inc.php
+++ b/core/lookuptable.class.inc.php
@@ -158,8 +158,8 @@ class LookupTable
 					Utils::Log(LOG_DEBUG, "No mapping found with key: '$sLookupKey', '$sDestField' will be set to zero.");
 				} else {
 					Utils::Log(LOG_WARNING, "No mapping found with key: '$sLookupKey', '$sDestField' will be set to zero.");
+					$bRet = false;
 				}
-				$bRet = false;
 			} else {
 				$iPos = $this->aFieldsPos[$sDestField];
 				if ($iPos !== null) {


### PR DESCRIPTION
if the LookupTable set to "ignore-errors" the Lookup itself should not return false in this case. Otherwise the line will be ignored in any case if you follow the documentation [collector-base on iTophub](https://www.itophub.io/wiki/page?id=extensions:itop-data-collector-base#advanced_lookups). The Best-Practise should be to **throw New IgnoredRowException** if the lookup function return false AND if the ignore_errors was set to false for the LookupTable Object in general.
Please correct me if i am wrong.

Best Regards
David from ITOMIG

(If you implement this pull request - i think no configuration or side impact should be considered - just locally tested)