### PR TITLE
N°7507 - Bump php/phpunit libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,6 @@
        "ext-libxml": "*"
    },
    "require-dev": {
-       "phpunit/phpunit": "^6"
+     "phpunit/phpunit": "^9"
    }
 }

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -23,7 +23,7 @@ class ParametersTest extends TestCase {
 
 		$sDumpParameters = $oParameters->Dump();
 
-		$this->assertContains($sExpectedDump, $sDumpParameters);
+		$this->assertStringContainsString($sExpectedDump, $sDumpParameters);
 	}
 
 	public function ToXMLProvider() {


### PR DESCRIPTION
Bump php to 7.3 minimum and phpunit to ^9