### PR TITLE
Fix N°7338 to actually use "itop_login"

### DIFF
--- a/core/orchestrator.class.inc.php
+++ b/core/orchestrator.class.inc.php
@@ -175,7 +175,7 @@ class Orchestrator
 				Utils::Log(LOG_ERR, "Unable to find the contact with email = '$sEmailToNotify'. No contact to notify will be defined.");
 			}
 		}
-		$sSynchroUser = Utils::GetConfigurationValue('synchro_user', Utils::GetConfigurationValue('itop_login', ''));
+		$sSynchroUser = Utils::GetConfigurationValue('synchro_user') ?: Utils::GetConfigurationValue('itop_login');
 		$aPlaceholders['$synchro_user$'] = 0;
 		if ($sSynchroUser != '') {
 			$oRestClient = new RestClient();


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°7338
| Type of change?                                               | Bug fix


## Symptom

Since #43, the documentation said it would use `itop_login` as fallback if no `synchro_user` was set. But this is wrong and it does not set any `synchro_user`.

## Reproduction procedure

1. With any collector
2. Do not set a value for `synchro_user`
3. Run `exec.php --configure_only`
4. Observe on iTop the **User** field of the _Synchro Data Source_ to be empty.

## Cause

The problem exists because the `Parameters::Get` method only checks if the key exists and then returns it, but since `<synchro_user></synchro_user>` is present in the `params.distrib.xml` file, it never tries to get the value for `itop_login`.

## Proposed solution
See code

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
