### PR TITLE
Fix default date_format

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -107,5 +107,5 @@
   <!-- iTop user set as allowed to run synchronization. It is highly recommended to use the same as itop_login. By default, it is the same as itop_login -->
   <synchro_user></synchro_user>
   <!-- date format in collected data -->
-  <date_format>Y-m-d</date_format>
+  <date_format>Y-m-d H:i:s</date_format>
 </parameters>

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -692,7 +692,7 @@ abstract class Collector
 				'output' => $sOutput,
 				'csvdata' => file_get_contents($sDataFile),
 				'charset' => $this->GetCharset(),
-                'date_format' => Utils::GetConfigurationValue('date_format', 'Y-m-d')
+                'date_format' => Utils::GetConfigurationValue('date_format', 'Y-m-d H:i:s')
 			);
 
 			$sLoginform = Utils::GetLoginMode();

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -708,6 +708,8 @@ abstract class Collector
 				Utils::Log(LOG_ERR, $sTrimmedOutput);
 
 				return false;
+			} else {
+				Utils::Log(LOG_DEBUG, $sTrimmedOutput);
 			}
 		}
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | #45
| Type of change?                                               | Bug fix


## Symptom

Some collectors didn't seem to synchronise a date(time) field anymore (since 1.4.0)

## Reproduction procedure

1. With teemip-ip-discovery-collector 3.1.3
4. Run a collection + synchro
5. Then observe in iTop that the **Last discovery date** isn't updated.

## Cause

itop-data-collector-base 1.4.0 introduced a new setting with a default value which wasn't the same as the previous behaviour.


## Proposed solution

Use the previous behaviour as the default value for the `date_format` setting. The other change provides useful debug data even when no errors detected on the import, like:
> 0: Wrong format for DATETIME column 3: ‘2024-06-13 14:05:09’ does not match the expected format: ‘Y-m-d’ (column skipped)

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
