### PR TITLE
N°7783 - Relative paths cannot beused when the collector is not launched from its home directory

### DIFF
--- a/core/jsoncollector.class.inc.php
+++ b/core/jsoncollector.class.inc.php
@@ -150,7 +150,11 @@ abstract class JsonCollector extends Collector
 			Utils::Log(LOG_DEBUG, 'Source sFileJson: '.$this->sFileJson);
 			Utils::Log(LOG_INFO, 'Synchro URL (target): '.Utils::GetConfigurationValue('itop_url', array()));
 		} else {
-			$this->sFileJson = file_get_contents($this->sFilePath);
+            $this->sFileJson = file_get_contents($this->sFilePath);
+            if ($this->sFileJson === false) {
+                $this->sFilePath = APPROOT.$this->sFilePath;
+                $this->sFileJson = file_get_contents($this->sFilePath);
+            }
 			Utils::Log(LOG_DEBUG, 'Source sFileJson: '.$this->sFileJson);
 			Utils::Log(LOG_INFO, 'Synchro  URL (target): '.Utils::GetConfigurationValue('itop_url', array()));
 		}

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -119,6 +119,7 @@ class JsonCollectorTest extends TestCase
 			"sort of object xpath parsing via an index" => [ "format_json_5" ],
 			"first row nullified function" => [ "nullified_json_1" ],
 			"another row nullified function" => [ "nullified_json_2" ],
+            "json file with relative path" => [ "json_file_with_relative_path" ],
 		];
 	}
 

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -108,7 +108,7 @@ class JsonCollectorTest extends TestCase
 		$this->assertEquals($sExpected_content, file_get_contents(APPROOT."/data/ITopPersonJsonCollector-1.csv"));
 	}
 
-	public function OrgCollectorProvider()
+	public static function OrgCollectorProvider()
 	{
 		return [
 			"default_value" => [ "default_value" ],
@@ -168,7 +168,7 @@ class JsonCollectorTest extends TestCase
 		}
 	}
 
-	public function ErrorFileProvider()
+	public static function ErrorFileProvider()
 	{
 		return [
 			"error_json_1" => [

--- a/test/single_json/json_file_with_relative_path/dataTest.json
+++ b/test/single_json/json_file_with_relative_path/dataTest.json
@@ -1,0 +1,38 @@
+{
+    "objects": {
+        "Person::1": {
+            "key": "1",
+            "name": {"bob": "My last name"},
+            "status": "active",
+            "org_id": "Blala",
+            "email": "my.email@foo.org",
+            "phone": "+00 000 000 000",
+            "notify": "yes",
+            "function": "",
+            "first_nameyo": "My first name"
+        },
+        "Person::2": {
+            "key": "2",
+            "name": {"bob":  "Picasso"},
+            "status": "active",
+            "org_id": "Demo",
+            "email": "pablo@demo.com",
+            "phone": "",
+            "notify": "yes",
+            "function": "",
+            "first_nameyo": "Pablo"
+        },
+        "Person::3": {
+            "key": "3",
+            "name": {"bob":  "Dali"},
+            "status": "active",
+            "email": "dali@demo.com",
+            "phone": "",
+            "notify": "yes",
+            "function": "",
+            "first_nameyo": "Salvador"
+        }
+    },
+    "code": 0,
+    "message": "Found: 1"
+}

--- a/test/single_json/json_file_with_relative_path/expected_generated.csv
+++ b/test/single_json/json_file_with_relative_path/expected_generated.csv
@@ -1,0 +1,4 @@
+primary_key;name;status;first_name;email;phone;function;org_id
+1;"My last name";active;"My first name";my.email@foo.org;"+00 000 000 000";;Blala
+2;Picasso;active;Pablo;pablo@demo.com;123456789;;Demo
+3;Dali;active;Salvador;dali@demo.com;123456789;;Demo

--- a/test/single_json/json_file_with_relative_path/params.distrib.xml
+++ b/test/single_json/json_file_with_relative_path/params.distrib.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default values for parameters. Do NOT alter this file, use params.local.xml in the conf folder instead -->
+<parameters>
+	<itoppersonjsoncollector>
+		<jsonfile>collectors/dataTest.json</jsonfile>
+		<path>objects/*</path>
+		<fields>
+			<primary_key>key</primary_key>
+			<name>name/bob</name>
+			<status>status</status>
+			<first_name>first_nameyo</first_name>
+			<email>email</email>
+			<phone>phone</phone>
+			<mobile_phone>mobile</mobile_phone>
+			<function>function</function>
+			<employee_number>employeenumber</employee_number>
+			<org_id>org_id</org_id>
+		</fields>
+		<defaults>
+			<org_id>Demo</org_id>
+			<status>active</status>
+			<phone>123456789</phone>
+		</defaults>
+	</itoppersonjsoncollector>
+	<json_placeholders>
+		<!-- For compatibility with the version 1.1.x of the collector, define the data table names as following:
+		<prefix></prefix>
+		<persons_data_table>synchro_data_PersonAD</persons_data_table>
+		<users_data_table></users_data_table>
+		 -->
+		<prefix>$prefix$</prefix>
+		<persons_data_table>synchro_data_person_1</persons_data_table>
+	</json_placeholders>
+</parameters>


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=7783
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
The json collector included in itop-data-collector-base may get its source information from a json file located on the server hosting the collector. In such case, the parameter jsonfile defines the name of the file to be used by the collector together with its path to access it. The path may be absolute or relative to the directory where the collector is deployed (let's call it <collector>).

When a relative path is used to reference the json file (for instance data/myjsonfile.json) and when the collector is not launched from the directory <collector>, the json collector cannot locate the json file, logs the following error and stops.

Error:
PHP Warning:  file_get_contents(data/myjsonfile.json): Failed to open stream: No such file or directory in /my-root-dir/my-collector/core/jsoncollector.class.inc.php on line xyz
...
[2025-01-02 13:31:26]	[Error]	[MyJsonCollector] Failed to get JSON file: 
[2025-01-02 13:31:26]	[Error]	MyJsonCollector::Prepare() returned false

When can live with the bug by always specifying absolute paths in the configuration file. This implies that specific params.local.xml file must be provided for phpunit tests. The PR get rid of this requirement.

## Reproduction procedure (bug)
1. With itop-data-collector-base 1.4.0
2. With PHP 8.3.15
3. Deploy a collector base under a working directory that we'll name <my-collector>
4. Create a json collector. Don't specify any jsonurl parameter but specify a jsonfile one using a relative path like 'data/myjsonfile'.
5. Run the collector from <my-collector>, everything will work fine.
6. If you run it from another directory, the collector will break.

## Cause (bug)
The json collector doesn't handle the case where the source file may be defined with a relative path. See line 153 of core/jsoncollector.class.inc.php:

## Proposed solution (bug and enhancement)
Add a test after the first read of the jsonfile. If it fails, retry with the APPROOT constant prepended to it.

## Checklist before requesting a review
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->
