### PR TITLE
N°8162 - Issue when synchronizing datasource with read-only notify_contact_id_archive_flag

### DIFF
--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -979,7 +979,7 @@ abstract class Collector
 		foreach ($aDS1 as $sKey => $value) {
 			if (in_array($sKey, Collector::READONLY_FIELDS)){
 				// Ignore all read-only attributes
-				break;
+				continue;
 			}
 
 			switch ($sKey) {
@@ -993,12 +993,12 @@ abstract class Collector
 								Utils::Log(LOG_DEBUG, "Comparison: ignoring the missing, but optional, attribute: '$sAttCode'.");
 								$this->aSkippedAttributes[] = $sAttCode;
 								continue;
-							} else {
-								// Missing non-optional attribute
-								Utils::Log(LOG_DEBUG, "Comparison: The definition of the non-optional attribute '$sAttCode' is missing. Data sources differ.");
-
-								return false;
 							}
+
+							// Missing non-optional attribute
+							Utils::Log(LOG_DEBUG, "Comparison: The definition of the non-optional attribute '$sAttCode' is missing. Data sources differ.");
+
+							return false;
 
 						} else {
 							if (($aDef != $aDef2) && (!$this->AttributeIsOptional($sAttCode))) {
@@ -1034,13 +1034,12 @@ abstract class Collector
 		foreach ($aDS2 as $sKey => $value) {
 			if (in_array($sKey, Collector::READONLY_FIELDS)){
 				// Ignore all read-only attributes
-				break;
+				continue;
 			}
 
-			if (!array_key_exists($sKey, $aDS1)) {
+			if (! array_key_exists($sKey, $aDS1)) {
+				//locally unknown fields can NOT be updated. so it is useless to update datasynchro on itop
 				Utils::Log(LOG_DEBUG, "Comparison: Found an extra property '$sKey' in iTop. Data sources differ.");
-
-				return false;
 			}
 		}
 

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -495,7 +495,7 @@ abstract class Collector
 			} else {
 				$iCount = ($aResult['objects'] !== null) ? count($aResult['objects']) : 0;
 				switch ($iCount) {
-					²0:
+					case 0:
 						// not found, need to create the Source
 						Utils::Log(LOG_INFO, "There is no Synchro Data Source named '{$this->sSourceName}' in iTop. Let's create it.");
 						$key = $this->CreateSynchroDataSource($aExpectedSourceDefinition, $this->GetName());

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -196,12 +196,9 @@ class RestClient
 		}
 
 		// Don't care about these read-only fields
-		unset($aSource['friendlyname']);
-		unset($aSource['user_id_friendlyname']);
-		unset($aSource['user_id_finalclass_recall']);
-		unset($aSource['notify_contact_id_friendlyname']);
-		unset($aSource['notify_contact_id_finalclass_recall']);
-		unset($aSource['notify_contact_id_obsolescence_flag']);
+		foreach (Collector::READONLY_FIELDS as $sField){
+			unset($aSource[$sField]);
+		}
 
 		return $bResult;
 	}

--- a/test/collector/attribute_isnullified/iTopPersonCollector.class.inc.php
+++ b/test/collector/attribute_isnullified/iTopPersonCollector.class.inc.php
@@ -3,6 +3,7 @@
 class iTopPersonCollector extends Collector
 {
 	private $bFetched;
+	private $aOptionalAttributes;
 
 	protected function Fetch()
 	{
@@ -24,13 +25,37 @@ class iTopPersonCollector extends Collector
 
 		return null;
 	}
-	
+
+	/**
+	 * @return array
+	 */
+	public function GetOptionalAttributes() {
+		if (! isset($this->aOptionalAttributes)){
+			return ['optional'];
+		}
+		return $this->aOptionalAttributes;
+	}
+
+	/**
+	 * @param array $aOptionalAttributes
+	 */
+	public function SetOptionalAttributes($aOptionalAttributes) {
+		$this->aOptionalAttributes = $aOptionalAttributes;
+	}
+
+
 	/**
 	 * {@inheritDoc}
 	 * @see Collector::AttributeIsOptional()
 	 */
 	public function AttributeIsOptional($sAttCode)
 	{
-	    return ($sAttCode === 'optional');
+		foreach ($this->GetOptionalAttributes() as $sAttOptionalCode){
+			if ($sAttCode === $sAttOptionalCode){
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/test/collector/datasources/ds1.json
+++ b/test/collector/datasources/ds1.json
@@ -1,0 +1,50 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "0",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/test/collector/datasources/ds1_oneadditional_field.json
+++ b/test/collector/datasources/ds1_oneadditional_field.json
@@ -1,0 +1,51 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "0",
+  "delete_policy_retention2": "0",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/test/collector/datasources/ds1_oneadditional_field_readonlytesting.json
+++ b/test/collector/datasources/ds1_oneadditional_field_readonlytesting.json
@@ -1,0 +1,51 @@
+{
+  "ADDITIONAL_FIELD_NAME" : "",
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "delete_policy_retention_value",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/test/collector/datasources/ds1_oneadditionnal_attributelist_field.json
+++ b/test/collector/datasources/ds1_oneadditionnal_attributelist_field.json
@@ -1,0 +1,58 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "0",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "name",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/test/collector/datasources/ds1_onefieldvalue_different.json
+++ b/test/collector/datasources/ds1_onefieldvalue_different.json
@@ -1,0 +1,50 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "1",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/test/collector/datasources/ds1_readonly_fields_different.json
+++ b/test/collector/datasources/ds1_readonly_fields_different.json
@@ -1,0 +1,50 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "0",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "&",
+  "user_id_friendlyame": "1",
+  "user_id_finalclass_recall": "2",
+  "notify_contact_id_friendlyname": 3,
+  "notify_contact_id_finalclass_recall": 4,
+  "notify_contact_id_archive_flag": "5",
+  "notify_contact_id_obsolescence_flag": "6"
+}

--- a/test/collector/datasources/ds1_same_attributelist_fields_onedifferentvalue.json
+++ b/test/collector/datasources/ds1_same_attributelist_fields_onedifferentvalue.json
@@ -1,0 +1,50 @@
+{
+  "name": "$prefix$Synchro CSV Person",
+  "description": "Synchronization of persons from CSV",
+  "status": "$synchro_status$",
+  "user_id": "$synchro_user$",
+  "notify_contact_id": "$contact_to_notify$",
+  "scope_class": "Person",
+  "database_table_name": "$persons_data_table$",
+  "scope_restriction": "",
+  "full_load_periodicity": "$full_load_interval$",
+  "reconciliation_policy": "use_primary_key",
+  "action_on_zero": "create",
+  "action_on_one": "update",
+  "action_on_multiple": "error",
+  "delete_policy": "ignore",
+  "delete_policy_update": "",
+  "delete_policy_retention": "0",
+  "attribute_list": [
+    {
+      "attcode": "status",
+      "update": "1",
+      "reconcile": "0",
+      "update_policy": "master_locked",
+      "finalclass": "SynchroAttribute",
+      "friendlyname": "status"
+    },
+    {
+      "attcode": "team_list",
+      "update": "0",
+      "reconcile": "1",
+      "update_policy": "master_locked",
+      "row_separator": "|",
+      "attribute_separator": ";",
+      "value_separator": ":",
+      "attribute_qualifier": "'",
+      "finalclass": "SynchroAttLinkSet",
+      "friendlyname": "team_list"
+    }
+  ],
+  "user_delete_policy": "nobody",
+  "url_icon": "",
+  "url_application": "",
+  "friendlyname": "",
+  "user_id_friendlyname": "",
+  "user_id_finalclass_recall": "",
+  "notify_contact_id_friendlyname": "",
+  "notify_contact_id_finalclass_recall": "",
+  "notify_contact_id_archive_flag": "",
+  "notify_contact_id_obsolescence_flag": ""
+}

--- a/toolkit/dump_tasks.php
+++ b/toolkit/dump_tasks.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright (C) 2014 Combodo SARL
 //
-//   This application is free software; you can redistribute it and/or modify	
+//   This application is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.
@@ -26,6 +26,7 @@ require_once(APPROOT.'core/parameters.class.inc.php');
 require_once(APPROOT.'core/ioexception.class.inc.php');
 require_once(APPROOT.'core/utils.class.inc.php');
 require_once(APPROOT.'core/restclient.class.inc.php');
+require_once(APPROOT.'core/collector.class.inc.php');
 
 $sTaskName = Utils::ReadParameter('task_name', '*');
 Utils::InitConsoleLogLevel();


### PR DESCRIPTION
### **Purpose**
Current PR aims at gathering all special attributes at the same place. These attributes should not be taken into account to deal with datasource computation/synchronization. 

### **Symptom**
Datasource synchronization may fail with below error due to a regression (PR 32/ N°6115):
`[Error] Failed to update the SynchroDataSource 'XXX' (2). Reason: Error: notify_contact_id_archive_flag: Attempting to set the value on the read-only attribute SynchroDataSource::notify_contact_id_archive_flag (100)`

### **Corollary**
Datasource computation has been enhanced and related test coverage completed...



