### PR TITLE
N°9336 - Support switch_env when calling iTop (API & synchro)

### DIFF
--- a/conf/params.distrib.xml
+++ b/conf/params.distrib.xml
@@ -6,6 +6,7 @@
   <itop_password>admin</itop_password>
   <itop_token/>
   <itop_login_mode/>
+  <itop_env>production</itop_env>
 
   <!-- console_log_level: level of logging to console (std output)
   -1 : none, nothing will be logged to the console

--- a/core/collector.class.inc.php
+++ b/core/collector.class.inc.php
@@ -712,7 +712,8 @@ abstract class Collector
 			);
 
 			$sLoginform = Utils::GetLoginMode();
-			$sResult = self::CallItopViaHttp("/synchro/synchro_import.php?login_mode=$sLoginform",
+			$sEnv = Utils::GetSwitchEnv();
+			$sResult = self::CallItopViaHttp("/synchro/synchro_import.php?login_mode=$sLoginform&switch_env=$sEnv",
 				$aData);
 
 			$sTrimmedOutput = trim(strip_tags($sResult));
@@ -739,7 +740,8 @@ abstract class Collector
 		}
 
 		$sLoginform = Utils::GetLoginMode();
-		$sResult = self::CallItopViaHttp("/synchro/synchro_exec.php?login_mode=$sLoginform",
+		$sEnv = Utils::GetSwitchEnv();
+		$sResult = self::CallItopViaHttp("/synchro/synchro_exec.php?login_mode=$sLoginform&switch_env=$sEnv",
 			$aData);
 
 		$iErrorsCount = $this->ParseSynchroExecOutput($sResult);

--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -114,10 +114,12 @@ class RestClient
 		$aData = Utils::GetCredentials();
 		$aData['json_data'] = json_encode($aOperation);
 		$sLoginform = Utils::GetLoginMode();
-		$sUrl = sprintf('%s/webservices/rest.php?login_mode=%s&version=%s',
+		$sEnv = Utils::GetSwitchEnv();
+		$sUrl = sprintf('%s/webservices/rest.php?login_mode=%s&version=%s&switch_env=%s',
 			Utils::GetConfigurationValue('itop_url', ''),
 			$sLoginform,
-			$sVersion
+			$sVersion,
+			$sEnv
 		);
 		$aHeaders = array();
 		$aCurlOptions = Utils::GetCurlOptions();

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -336,6 +336,18 @@ class Utils
 		return 'form';
 	}
 
+
+	/**
+	 * Returns the iTop environment to use when connecting to the iTop API.
+	 *
+	 * @return string
+	 */
+	static public function GetSwitchEnv() : string {
+
+		return Utils::GetConfigurationValue('itop_env', 'production');
+
+	}
+
 	/**
 	 * Dump information about the configuration (value of the parameters)
 	 *

--- a/test/utils/params.test.xml
+++ b/test/utils/params.test.xml
@@ -5,6 +5,7 @@
   <itop_password>admin</itop_password>
   <itop_token></itop_token>
   <itop_login_mode></itop_login_mode>
+  <itop_env>production</itop_env>
   <console_log_level>6</console_log_level>
   <eventissue_log_level>-1</eventissue_log_level>
   <console_log_dateformat>[Y-m-d H:i:s]</console_log_dateformat>


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)

- The iTop API natively supports the use of the `switch_env` parameter.
- The data base collector should also support this.


## Proposed solution (bug and enhancement)

- An optional parameter that defaults to `production` .


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge

No new phpunit test as I don't know what environments Combodo has in place.
