### PR TITLE
Add detection of iTop API versions 1.3 and 1.4.

### DIFF
--- a/core/restclient.class.inc.php
+++ b/core/restclient.class.inc.php
@@ -129,21 +129,29 @@ class RestClient
 		return $aResults;
 	}
 
-	public static function GetNewestKnownVersion()
-	{
-		$sNewestVersion = '1.0';
+
+	/**
+	 * Gets the iTop API version in use. It tries all the known versions, starting from the newest one.
+	 *
+	 * @return void
+	 * @throws Exception If no supported version is found.
+	 */
+	public static function GetNewestKnownVersion() {
+
 		$oC = new RestClient();
-		$aKnownVersions = array('1.0', '1.1', '1.2', '2.0');
+		// Order: Put the newest versions first.
+		$aKnownVersions = array('1.4', '1.3', '1.2', '1.1', '1.0');
 		foreach ($aKnownVersions as $sVersion) {
 			$oC->SetVersion($sVersion);
 			$aRet = $oC->ListOperations();
 			if ($aRet['code'] == 0) {
-				// Supported version
-				$sNewestVersion = $sVersion;
+				// A non-error code (0) means the version is supported.
+				return $sVersion;
 			}
 		}
 
-		return $sNewestVersion;
+		throw new Exception("No supported iTop API version found (tried: ".implode(', ', $aKnownVersions).")");
+		
 	}
 
 	/**


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)

Enhancement: Ability to detect iTop API versions 1.3 and 1.4 ( https://www.itophub.io/wiki/page?id=latest:advancedtopics:rest_json#changes_history )

It also changes the logic to try most recent versions of the API first.



## Proposed solution (bug and enhancement)
<!--
Explain in details how you are proposing to solve this:
  - What did you do in the code and why
  - If you changed something in the UI, put before / after screenshots (you can paste image directly in this editor)
-->

Just add the missing values.


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

I'm not sure if Combodo internally has a version 2.0 of the API or why it's here already.
If needed, I'll add it back. Otherwise, it's just another API call that doesn't make any sense yet.

If no version is found, it will throw an exception now.