### PR TITLE
N°9662 - feat(Parameters): Add boolean element type

### DIFF
--- a/core/parameters.class.inc.php
+++ b/core/parameters.class.inc.php
@@ -166,7 +166,12 @@ class Parameters
 
 			case 'int':
 			case 'integer':
-				$value = (int)$oElement;
+				$value = filter_var($oElement, FILTER_VALIDATE_INT);
+				break;
+
+			case 'bool':
+			case 'boolean':
+				$value = filter_var($oElement, FILTER_VALIDATE_BOOL);
 				break;
 
 			case 'string':


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective

Add enhanced support for boolean parameters which can now contain `1`, `0`, `true`, `false`, `on`, `off`, `yes`, `no` and return the boolean representation to the collector.


## Proposed solution

Use integrated [FILTER_VALIDATE_BOOL](https://www.php.net/manual/en/filter.constants.php#constant.filter-validate-bool).

No Unit test added, since there's no existing test for the modified method.

## Checklist before requesting a review
- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code

