### PR TITLE
feat(Parameters): Dump integers with type attribute

### DIFF
--- a/core/parameters.class.inc.php
+++ b/core/parameters.class.inc.php
@@ -84,6 +84,7 @@ class Parameters
 				}
 			}
 		} else {
+			if (is_int($data)) $oNode->setAttribute('type', 'int');
 			$oTextNode = $oRoot->ownerDocument->createTextNode($data);
 			$oNode->appendChild($oTextNode);
 		}

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -40,6 +40,10 @@ class ParametersTest extends TestCase
 				'aData' => ['paramroot' => ['param1' => 'param1val', 'param2' => 'param2val']],
 				'sExpectedDump' => "<paramroot>\n    <param1>param1val</param1>\n    <param2>param2val</param2>\n  </paramroot>",
 			],
+			'Parameter with integer' => [
+				'aData' => ['my_int' => 42],
+				'sExpectedDump' => '<my_int type="int">42</my_int>',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective

The dump should keep/store the type attributes from the original parameters file.

## Proposed solution

Add `type="int"` attribute when the value is an integer.

## Checklist before requesting a review

- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
