### PR TITLE
N°9735 - fix(Orchestrator): Gracefully catch exceptions from Synchronize step

### DIFF
--- a/core/orchestrator.class.inc.php
+++ b/core/orchestrator.class.inc.php
@@ -265,8 +265,13 @@ class Orchestrator
 		$bStopOnError = ($sStopOnError == 'yes');
 		/** @var \Collector $oCollector */
 		foreach ($aCollectors as $oCollector) {
-			Utils::SetCollector($oCollector, "Synchronize");
-			$bResult = $oCollector->Synchronize();
+			try {
+				Utils::SetCollector($oCollector, "Synchronize");
+				$bResult = $oCollector->Synchronize();
+			} catch (Exception $e) {
+				Utils::Log(LOG_ERR, sprintf('Synchronization exception: %s', $e->getMessage()));
+				$bResult = false;
+			}
 			if (!$bResult) {
 				if ($bStopOnError) {
 					break;


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix


## Symptom

When one of the collectors throws an exception, the complete synchronisation process will stop even when `stop_on_synchro_error` is disabled.

## Reproduction procedure

1. Have a collector that throws an exception during its synchronisation process (`DoProcessBeforeSynchro`)
2. Run synchro.

## Cause

Exception thrown by `Collector::Synchronize` aren't catched inside `Orchestrator::Synchronize`.

## Proposed solution

Catch exception thrown by `Collector::Synchronize` inside `Orchestrator::Synchronize` and log its message before continuing to the next collector.

## Checklist before requesting a review

- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code