### PR TITLE
N°9661 - feat(Utils): Add validation to `GetConfigurationValue`

### DIFF
--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -312,7 +312,7 @@ class Utils
 		$value = self::Substitute($value);
 
 		if ($iFilter) {
-			$iOptions = FILTER_FLAG_NONE | (is_array($value) ? FILTER_REQUIRE_ARRAY : 0);
+			$iOptions = FILTER_NULL_ON_FAILURE | (is_array($value) ? FILTER_REQUIRE_ARRAY : 0);
 			$value = filter_var($value, $iFilter, $iOptions);
 			$value ??= filter_var($defaultValue, $iFilter, $iOptions) ?? $defaultValue;
 		}

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -29,7 +29,7 @@ class Utils
 	public static $sProjectName = "";
 	public static $sStep = "";
 	public static $oCollector = "";
-	protected static $oConfig = null;
+	protected static Parameters|null $oConfig;
 	protected static $aConfigFiles = [];
 	protected static $iMockLogLevel = LOG_ERR;
 
@@ -295,11 +295,14 @@ class Utils
 	 *
 	 * @param string $sCode
 	 * @param mixed $defaultValue
+	 * @param int $iFilter The filter to apply
 	 *
 	 * @return mixed
 	 * @throws Exception
+	 *
+	 * @see filter_var()
 	 */
-	public static function GetConfigurationValue($sCode, $defaultValue = '')
+	public static function GetConfigurationValue(string $sCode, mixed $defaultValue = '', int $iFilter = FILTER_FLAG_NONE): mixed
 	{
 		if (self::$oConfig == null) {
 			self::LoadConfig();
@@ -307,6 +310,11 @@ class Utils
 
 		$value = self::$oConfig->Get($sCode, $defaultValue);
 		$value = self::Substitute($value);
+
+		if ($iFilter) {
+			$value = filter_var($value, $iFilter, FILTER_NULL_ON_FAILURE);
+			$value ??= filter_var($defaultValue, $iFilter, FILTER_NULL_ON_FAILURE) ?? $defaultValue;
+		}
 
 		return $value;
 	}

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -312,8 +312,9 @@ class Utils
 		$value = self::Substitute($value);
 
 		if ($iFilter) {
-			$value = filter_var($value, $iFilter, FILTER_NULL_ON_FAILURE);
-			$value ??= filter_var($defaultValue, $iFilter, FILTER_NULL_ON_FAILURE) ?? $defaultValue;
+			$iOptions = FILTER_FLAG_NONE | (is_array($value) ? FILTER_REQUIRE_ARRAY : 0);
+			$value = filter_var($value, $iFilter, $iOptions);
+			$value ??= filter_var($defaultValue, $iFilter, $iOptions) ?? $defaultValue;
 		}
 
 		return $value;

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -2,6 +2,8 @@
 
 namespace UnitTestFiles\Test;
 
+use Exception;
+use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\TestCase;
 use RestClient;
 use Utils;
@@ -310,5 +312,123 @@ class UtilsTest extends TestCase
 		$oRestClient = $this->PrepareCheckModuleInstallation(1);
 		$this->expectExceptionMessage('Required iTop module fake-module is considered as not installed due to: Found: 0');
 		Utils::GetModuleVersion('fake-module', $oRestClient);
+	}
+
+	public function GetConfigurationValueProvider(): array
+	{
+		return [
+			'simple string value' => [
+				'sValue' => 'foobar',
+				'default' => '',
+				'expected' => 'foobar',
+			],
+			'default string value' => [
+				'sValue' => null,
+				'default' => 'foobar',
+				'expected' => 'foobar',
+			],
+			'integer simple value' => [
+				'sValue' => '123',
+				'default' => '',
+				'expected' => '123',
+			],
+			'integer default value' => [
+				'sValue' => null,
+				'default' => 123,
+				'expected' => 123,
+			],
+			'integer filter value' => [
+				'sValue' => '123',
+				'default' => '',
+				'expected' => 123,
+				'iFilter' => FILTER_VALIDATE_INT,
+			],
+			'integer filter default value' => [
+				'sValue' => null,
+				'default' => 123,
+				'expected' => 123,
+				'iFilter' => FILTER_VALIDATE_INT,
+			],
+			'integer filter wrong value' => [
+				'sValue' => 'foobar',
+				'default' => 123,
+				'expected' => 123,
+				'iFilter' => FILTER_VALIDATE_INT,
+			],
+			'boolean simple value' => [
+				'sValue' => 'yes',
+				'default' => '',
+				'expected' => 'yes',
+			],
+			'boolean default value' => [
+				'sValue' => null,
+				'default' => true,
+				'expected' => true,
+			],
+			'boolean filter value yes' => [
+				'sValue' => 'yes',
+				'default' => '',
+				'expected' => true,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter value no' => [
+				'sValue' => 'no',
+				'default' => '',
+				'expected' => false,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter value true' => [
+				'sValue' => 'true',
+				'default' => '',
+				'expected' => true,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter value false' => [
+				'sValue' => 'false',
+				'default' => '',
+				'expected' => false,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter default value' => [
+				'sValue' => null,
+				'default' => 'yes',
+				'expected' => true,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter wrong value' => [
+				'sValue' => 'foobar',
+				'default' => 'yes',
+				'expected' => true,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'boolean filter wrong default value' => [
+				'sValue' => null,
+				'default' => 'foobar',
+				'expected' => 'foobar',
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider GetConfigurationValueProvider
+	 * @throws Exception
+	 */
+	public function testGetConfigurationValue($sValue, $default, $expected, $iFilter = FILTER_FLAG_NONE)
+	{
+		$oParametersMock = $this->createMock(\Parameters::class);
+		$oParametersMock->expects($this->exactly(1))
+			->method('Get')
+			->will($this->returnCallback(
+				function ($sCode, $default = '') use ($sValue) {
+					return is_null($sValue) ? $default : $sValue;
+				}
+			));
+
+		$oConfigProperty = new \ReflectionProperty(Utils::class, 'oConfig');
+		$oConfigProperty->setValue(null, $oParametersMock);
+
+		// Note: assertEquals did not seem to be type-safe
+		$this->assertThat(Utils::GetConfigurationValue('foobar', $default, $iFilter), new IsIdentical($expected));
 	}
 }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -318,95 +318,133 @@ class UtilsTest extends TestCase
 	{
 		return [
 			'simple string value' => [
-				'sValue' => 'foobar',
+				'value' => 'foobar',
 				'default' => '',
 				'expected' => 'foobar',
 			],
 			'default string value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => 'foobar',
 				'expected' => 'foobar',
 			],
 			'integer simple value' => [
-				'sValue' => '123',
+				'value' => '123',
 				'default' => '',
 				'expected' => '123',
 			],
 			'integer default value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => 123,
 				'expected' => 123,
 			],
 			'integer filter value' => [
-				'sValue' => '123',
+				'value' => '123',
 				'default' => '',
 				'expected' => 123,
 				'iFilter' => FILTER_VALIDATE_INT,
 			],
 			'integer filter default value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => 123,
 				'expected' => 123,
 				'iFilter' => FILTER_VALIDATE_INT,
 			],
 			'integer filter wrong value' => [
-				'sValue' => 'foobar',
+				'value' => 'foobar',
 				'default' => 123,
 				'expected' => 123,
 				'iFilter' => FILTER_VALIDATE_INT,
 			],
 			'boolean simple value' => [
-				'sValue' => 'yes',
+				'value' => 'yes',
 				'default' => '',
 				'expected' => 'yes',
 			],
 			'boolean default value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => true,
 				'expected' => true,
 			],
 			'boolean filter value yes' => [
-				'sValue' => 'yes',
+				'value' => 'yes',
 				'default' => '',
 				'expected' => true,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter value no' => [
-				'sValue' => 'no',
+				'value' => 'no',
 				'default' => '',
 				'expected' => false,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter value true' => [
-				'sValue' => 'true',
+				'value' => 'true',
 				'default' => '',
 				'expected' => true,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter value false' => [
-				'sValue' => 'false',
+				'value' => 'false',
 				'default' => '',
 				'expected' => false,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter default value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => 'yes',
 				'expected' => true,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter wrong value' => [
-				'sValue' => 'foobar',
+				'value' => 'foobar',
 				'default' => 'yes',
 				'expected' => true,
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
 			'boolean filter wrong default value' => [
-				'sValue' => null,
+				'value' => null,
 				'default' => 'foobar',
 				'expected' => 'foobar',
 				'iFilter' => FILTER_VALIDATE_BOOLEAN,
 			],
+			'boolean filter empty default value' => [
+				'value' => null,
+				'default' => '',
+				'expected' => false,
+				'iFilter' => FILTER_VALIDATE_BOOLEAN,
+			],
+			'array simple value' => [
+				'value' => ['foo','bar','baz'],
+				'default' => '',
+				'expected' => ['foo','bar','baz'],
+			],
+			'array default value' => [
+				'value' => null,
+				'default' => ['foo','bar','baz'],
+				'expected' => ['foo','bar','baz'],
+			],
+			'array filter integer value' => [
+				'value' => ['123','456'],
+				'default' => '',
+				'expected' => [123,456],
+				'iFilter' => FILTER_VALIDATE_INT,
+			],
+			'hash filter value' => [
+				'value' => ['foo' => 'bar'],
+				'default' => '',
+				'expected' => ['foo' => 'bar'],
+			],
+			'hash default value' => [
+				'value' => null,
+				'default' => ['foo' => 'bar'],
+				'expected' => ['foo' => 'bar'],
+			],
+			'hash filter integer value' => [
+				'value' => ['foo' => '123', 'bar' => '456'],
+				'default' => '',
+				'expected' => ['foo' => 123, 'bar' => 456],
+				'iFilter' => FILTER_VALIDATE_INT,
+			]
 		];
 	}
 
@@ -414,14 +452,14 @@ class UtilsTest extends TestCase
 	 * @dataProvider GetConfigurationValueProvider
 	 * @throws Exception
 	 */
-	public function testGetConfigurationValue($sValue, $default, $expected, $iFilter = FILTER_FLAG_NONE)
+	public function testGetConfigurationValue($value, $default, $expected, $iFilter = FILTER_FLAG_NONE)
 	{
 		$oParametersMock = $this->createMock(\Parameters::class);
 		$oParametersMock->expects($this->exactly(1))
 			->method('Get')
 			->will($this->returnCallback(
-				function ($sCode, $default = '') use ($sValue) {
-					return is_null($sValue) ? $default : $sValue;
+				function ($sCode, $default = '') use ($value) {
+					return is_null($value) ? $default : $value;
 				}
 			));
 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -444,7 +444,13 @@ class UtilsTest extends TestCase
 				'default' => '',
 				'expected' => ['foo' => 123, 'bar' => 456],
 				'iFilter' => FILTER_VALIDATE_INT,
-			]
+			],
+			'hash filter integer wrong value' => [
+				'value' => ['foo' => '123', 'bar' => 'baz'],
+				'default' => '',
+				'expected' => ['foo' => 123, 'bar' => null],
+				'iFilter' => FILTER_VALIDATE_INT,
+			],
 		];
 	}
 


### PR DESCRIPTION
## Base information

| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement

## Objective

When retrieving settings, you sometimes need to additional type checking validation. The objective is to reduce this as much as possible.

Before:
```php
$sStopOnError = Utils::GetConfigurationValue('stop_on_synchro_error', 'no');
if (($sStopOnError != 'yes') && ($sStopOnError != 'no')) {
	Utils::Log(LOG_WARNING, "Unexpected value '$sStopOnError' for the parameter 'stop_on_synchro_error'. Will NOT stop on error. The expected values for this parameter are 'yes' or 'no'.");
}
$bStopOnError = ($sStopOnError == 'yes');
```
After:
```php
$bStopOnError = Utils::GetConfigurationValue('stop_on_synchro_error', 'no', FILTER_VALIDATE_BOOLEAN);
```

## Proposed solution

Use php's integrated functionality to filter/validate variables by adding an optional filter flag to the `GetConfigurationValue` method. Current behaviour is not altered.

## Checklist before requesting a review

- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [ ] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code