### PR TITLE
N°9665 - feat: add PHP 8.4 and 8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
    "require": {
-       "php": ">=8.1 <8.4",
+       "php": ">=8.1 <8.6",
        "ext-libxml": "*"
    },
    "require-dev": {

--- a/core/utils.class.inc.php
+++ b/core/utils.class.inc.php
@@ -516,7 +516,7 @@ class Utils
 					$aResponseHeaders[$sName] = $sValue;
 				}
 			}
-			curl_close($ch);
+			unset($ch);
 		} else {
 			// cURL is not available let's try with streams and fopen...
 

--- a/test/CallItopServiceTest.php
+++ b/test/CallItopServiceTest.php
@@ -27,7 +27,6 @@ class CallItopServiceTest extends TestCase
 		Utils::MockDoPostRequestService(null);
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, null);
 	}
 
@@ -79,7 +78,6 @@ class CallItopServiceTest extends TestCase
 			));
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, $oParametersMock);
 
 		$oMockedDoPostRequestService = $this->createMock(DoPostRequestService::class);

--- a/test/CollectorTest.php
+++ b/test/CollectorTest.php
@@ -270,7 +270,6 @@ CSV;
 	{
 		$class = new \ReflectionClass($sObjectClass);
 		$method = $class->getMethod($sMethodName);
-		$method->setAccessible(true);
 
 		return $method->invokeArgs($oObject, $aArgs);
 	}

--- a/test/JsonCollectorTest.php
+++ b/test/JsonCollectorTest.php
@@ -409,7 +409,6 @@ JSON;
 
 		$class = new \ReflectionClass("JsonCollector");
 		$method = $class->getMethod("SearchFieldValues");
-		$method->setAccessible(true);
 		return $method->invokeArgs($oOrgCollector, [$aData, $aFieldPaths]);
 	}
 

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -52,7 +52,6 @@ class ParametersTest extends TestCase
 	{
 		$class = new \ReflectionClass($sClass);
 		$property = $class->getProperty($sProperty);
-		$property->setAccessible(true);
 
 		return $property;
 	}

--- a/test/RestTest.php
+++ b/test/RestTest.php
@@ -27,7 +27,6 @@ class RestTest extends TestCase
 		Utils::MockDoPostRequestService(null);
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, null);
 	}
 
@@ -97,7 +96,6 @@ class RestTest extends TestCase
 			));
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, $oParametersMock);
 
 		$oMockedDoPostRequestService = $this->createMock(DoPostRequestService::class);

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -26,7 +26,6 @@ class UtilsTest extends TestCase
 		Utils::MockLog(null);
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, null);
 	}
 
@@ -163,7 +162,6 @@ class UtilsTest extends TestCase
 			));
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, $oParametersMock);
 
 		$this->assertEquals($aExpectedCredentials, Utils::GetCredentials());
@@ -187,7 +185,6 @@ class UtilsTest extends TestCase
 			));
 
 		$reflection = new \ReflectionProperty(Utils::class, 'oConfig');
-		$reflection->setAccessible(true);
 		$reflection->setValue(null, $oParametersMock);
 
 		$this->assertEquals($sExpectedLoginMode, Utils::GetLoginMode());
@@ -247,12 +244,10 @@ class UtilsTest extends TestCase
 		$oRestClient = $this->createMock(RestClient::class);
 
 		$oReflectionLastInstallDate = new \ReflectionProperty(Utils::class, 'sLastInstallDate');
-		$oReflectionLastInstallDate->setAccessible(true);
 		$oReflectionLastInstallDate->setValue(null, '0000-00-00 00:00:00');
 
 		//reset cache
 		$oReflectionModuleVersions = new \ReflectionProperty(Utils::class, 'aModuleVersions');
-		$oReflectionModuleVersions->setAccessible(true);
 		$oReflectionModuleVersions->setValue(null, []);
 
 		$oRestClient->expects($this->exactly($iExpectedCallCount))


### PR DESCRIPTION
## Summary

- Extend PHP version constraint from `>=8.1 <8.4` to `>=8.1 <8.6` in `composer.json`
- Remove deprecated `ReflectionProperty::setAccessible()` and `ReflectionMethod::setAccessible()` calls in tests (deprecated in PHP 8.5, no-op since PHP 8.1)
- Replace `curl_close()` with `unset()` in `Utils` (`curl_close()` is deprecated in PHP 8.5, curl handles are freed automatically)

## Compatibility

Tested on PHP 8.1, 8.3, 8.4 and 8.5 — 135 tests, 300 assertions, all green, no deprecations.

## Test plan

- [x] Run `composer install && vendor/bin/phpunit test/` on PHP 8.1
- [x] Run `composer install && vendor/bin/phpunit test/` on PHP 8.4
- [x] Run `composer install && vendor/bin/phpunit test/` on PHP 8.5